### PR TITLE
Add modular Telegram bot skeleton

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+class Config:
+    API_ID = 12345
+    API_HASH = "your_api_hash"
+    BOT_TOKEN = "your_bot_token"
+    MONGO_URI = "mongodb://localhost:27017"
+    LOG_CHANNEL = -1001234567890
+    OWNER_ID = 123456789

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,9 @@
+import importlib
+import pkgutil
+
+
+def register_all(app):
+    for loader, name, ispkg in pkgutil.iter_modules(__path__):
+        module = importlib.import_module(f"{__name__}.{name}")
+        if hasattr(module, "register"):
+            module.register(app)

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,17 @@
+from pyrogram import filters
+from pyrogram.types import Message
+
+from utils import catch_errors, is_owner
+from config import Config
+
+
+def register(app):
+    @app.on_message(filters.command("broadcast") & filters.user(Config.OWNER_ID))
+    @catch_errors
+    async def broadcast_handler(client, message: Message):
+        if len(message.command) < 2:
+            await message.reply_text("Usage: /broadcast <text>")
+            return
+        text = message.text.split(None, 1)[1]
+        await message.reply_text(f"Broadcasting: {text}")
+        # Placeholder for broadcast logic

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -1,0 +1,21 @@
+from pyrogram import filters
+from pyrogram.types import Message
+
+from utils import catch_errors, safe_edit
+
+
+def register(app):
+    @app.on_message(filters.command("start"))
+    @catch_errors
+    async def start_handler(client, message: Message):
+        await message.reply_text("Hello! I'm a moderation bot.")
+
+    @app.on_message(filters.command("help"))
+    @catch_errors
+    async def help_handler(client, message: Message):
+        await message.reply_text("Help menu")
+
+    @app.on_message(filters.command("ping"))
+    @catch_errors
+    async def ping_handler(client, message: Message):
+        await message.reply_text("Pong!")

--- a/moderation.py
+++ b/moderation.py
@@ -1,0 +1,22 @@
+from pyrogram import filters
+from pyrogram.types import Message, ChatPermissions
+
+from utils import update_violation, catch_errors
+
+BANNED_WORDS = {"badword", "hate"}
+
+
+def register(app):
+    @app.on_message(filters.text & ~filters.private)
+    @catch_errors
+    async def text_moderation(client, message: Message):
+        if not message.from_user or message.from_user.is_self:
+            return
+        text = message.text.lower()
+        if any(word in text for word in BANNED_WORDS):
+            user = await update_violation(app.db, message.from_user.id, 10, "warned")
+            if user["violations"] >= 3:
+                await message.chat.restrict(message.from_user.id, ChatPermissions())
+                await message.reply_text("User muted for repeated violations.")
+            else:
+                await message.reply_text("Please keep the chat civil.")

--- a/run.py
+++ b/run.py
@@ -1,0 +1,38 @@
+import asyncio
+import logging
+from pyrogram import Client
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from config import Config
+import handlers
+import moderation
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    app = Client(
+        "bot",
+        api_id=Config.API_ID,
+        api_hash=Config.API_HASH,
+        bot_token=Config.BOT_TOKEN,
+        plugins=None,
+    )
+
+    db = AsyncIOMotorClient(Config.MONGO_URI).bot
+    app.db = db
+
+    await app.start()
+    logger.info("Bot started")
+    handlers.register_all(app)
+    moderation.register(app)
+    await idle()
+
+
+async def idle():
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility modules for the bot."""
+
+from .db import get_user, update_violation
+from .perms import is_admin, is_owner
+from .decorators import catch_errors
+from .formatting import safe_edit

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Dict, Any
+
+
+async def get_user(db, user_id: int) -> Dict[str, Any]:
+    user = await db.users.find_one({"_id": user_id})
+    if not user:
+        user = {"_id": user_id, "score": 0, "violations": 0, "last_action": None}
+        await db.users.insert_one(user)
+    return user
+
+
+async def update_violation(db, user_id: int, score_delta: int, action: str):
+    user = await get_user(db, user_id)
+    user["score"] += score_delta
+    user["violations"] += 1
+    user["last_action"] = action
+    await db.users.replace_one({"_id": user_id}, user, upsert=True)
+    return user

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,15 @@
+import functools
+import logging
+from pyrogram.types import Message
+
+logger = logging.getLogger(__name__)
+
+
+def catch_errors(func):
+    @functools.wraps(func)
+    async def wrapper(client, message: Message):
+        try:
+            return await func(client, message)
+        except Exception as e:
+            logger.exception("Error in handler: %s", e)
+    return wrapper

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,0 +1,8 @@
+from pyrogram.types import Message
+
+
+async def safe_edit(message: Message, text: str, **kwargs):
+    try:
+        await message.edit_text(text, **kwargs)
+    except Exception:
+        pass

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -1,0 +1,12 @@
+from pyrogram.types import Message
+
+
+def is_owner(user_id: int, owner_id: int) -> bool:
+    return user_id == owner_id
+
+
+async def is_admin(message: Message) -> bool:
+    if not message.chat or not message.from_user:
+        return False
+    member = await message.chat.get_member(message.from_user.id)
+    return member.status in ("administrator", "creator")


### PR DESCRIPTION
## Summary
- implement Config class
- add `run.py` to start the bot and load handlers
- implement basic moderation with banned word list
- add utility functions for db and permissions
- add general and admin command handlers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686b44618f1083298ef79dd50e521cdd