### PR TITLE
Add modular moderation bot features

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+class Config:
+    API_ID = 12345
+    API_HASH = "your_api_hash"
+    BOT_TOKEN = "your_bot_token"
+    MONGO_URI = "mongodb://localhost:27017"
+    LOG_CHANNEL = -1001234567890
+    OWNER_ID = 123456789
+    PERSPECTIVE_API_KEY = "perspective_key"
+    SIGHTENGINE_USER = "user"
+    SIGHTENGINE_SECRET = "secret"

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,9 @@
+import importlib
+import pkgutil
+
+
+def register_all(app):
+    for loader, name, ispkg in pkgutil.iter_modules(__path__):
+        module = importlib.import_module(f"{__name__}.{name}")
+        if hasattr(module, "register"):
+            module.register(app)

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,0 +1,43 @@
+from pyrogram import filters
+from pyrogram.types import Message
+
+from config import Config
+from utils import db, perms, errors, logger
+
+
+def register(app):
+    @app.on_message(filters.command("approve") & filters.group)
+    @errors.catch_errors
+    async def approve(client, message: Message):
+        if not await perms.is_admin(message):
+            return
+        if not message.reply_to_message:
+            await message.reply_text("Reply to a user to approve.")
+            return
+        user_id = message.reply_to_message.from_user.id
+        await db.set_approved(app.db, message.chat.id, user_id, True)
+        await message.reply_text("User approved")
+        await logger.log_action(app, f"Approved {user_id} in {message.chat.id}")
+
+    @app.on_message(filters.command("unapprove") & filters.group)
+    @errors.catch_errors
+    async def unapprove(client, message: Message):
+        if not await perms.is_admin(message):
+            return
+        if not message.reply_to_message:
+            await message.reply_text("Reply to a user to unapprove.")
+            return
+        user_id = message.reply_to_message.from_user.id
+        await db.set_approved(app.db, message.chat.id, user_id, False)
+        await message.reply_text("User unapproved")
+        await logger.log_action(app, f"Unapproved {user_id} in {message.chat.id}")
+
+    @app.on_message(filters.command("approved") & filters.group)
+    @errors.catch_errors
+    async def list_approved(client, message: Message):
+        if not await perms.is_admin(message):
+            return
+        users = await db.list_approved(app.db, message.chat.id)
+        text = "Approved users:\n" + "\n".join(str(u) for u in users)
+        await message.reply_text(text or "No approved users")
+

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -1,0 +1,23 @@
+from pyrogram import filters
+from pyrogram.types import Message
+
+from config import Config
+from utils import db, errors, logger
+
+
+def register(app):
+    @app.on_message(filters.command("broadcast") & filters.user(Config.OWNER_ID))
+    @errors.catch_errors
+    async def broadcast_handler(client, message: Message):
+        if len(message.command) < 2:
+            await message.reply_text("Usage: /broadcast <text>")
+            return
+        text = message.text.split(None, 1)[1]
+        groups = await db.get_groups(app.db)
+        for chat_id in groups:
+            try:
+                await client.send_message(chat_id, text)
+            except Exception:
+                pass
+        await message.reply_text("Broadcast sent")
+        await logger.log_action(app, "Broadcast executed")

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -1,0 +1,22 @@
+from pyrogram import filters
+from pyrogram.types import Message
+
+from utils import db, errors
+
+
+def register(app):
+    @app.on_message(filters.command("ping"))
+    @errors.catch_errors
+    async def ping(client, message: Message):
+        await message.reply_text("Pong!")
+
+    @app.on_message(filters.command("profile") & filters.private)
+    @errors.catch_errors
+    async def profile(client, message: Message):
+        user = await db.get_user(app.db, message.from_user.id)
+        text = (
+            f"👤 {message.from_user.mention}\n"
+            f"🧪 Toxicity Score: {user.get('score', 0)}\n"
+            f"Warnings: {user.get('warnings', {}).get(str(message.chat.id), 0)}"
+        )
+        await message.reply_text(text)

--- a/handlers/moderation.py
+++ b/handlers/moderation.py
@@ -1,0 +1,45 @@
+from pyrogram import filters
+from pyrogram.types import Message, ChatPermissions
+
+from utils import api, db, perms, logger, errors
+
+BANNED_WORDS = {"badword", "hate"}
+WARNING_LIMIT = 3
+
+
+def register(app):
+    @app.on_message(filters.text & ~filters.private)
+    @errors.catch_errors
+    async def check_text(client, message: Message):
+        if not message.from_user or await perms.is_admin(message):
+            return
+        user = await db.get_user(app.db, message.from_user.id)
+        if int(message.chat.id) in user.get("approved_in", []):
+            return
+        text = message.text or ""
+        if any(word in text.lower() for word in BANNED_WORDS):
+            toxicity = await api.check_text_toxicity(text)
+            warnings = await db.add_warning(app.db, message.chat.id, message.from_user.id, int(toxicity))
+            await logger.log_action(app, f"Warned {message.from_user.id} in {message.chat.id}. warnings={warnings}")
+            if warnings >= WARNING_LIMIT:
+                await message.chat.restrict(message.from_user.id, ChatPermissions())
+                await logger.log_action(app, f"Muted {message.from_user.id} in {message.chat.id}")
+            await message.delete()
+
+    @app.on_message((filters.photo | filters.sticker) & ~filters.private)
+    @errors.catch_errors
+    async def check_media(client, message: Message):
+        if not message.from_user or await perms.is_admin(message):
+            return
+        user = await db.get_user(app.db, message.from_user.id)
+        if int(message.chat.id) in user.get("approved_in", []):
+            return
+        if message.photo:
+            file = await message.download()
+            result = await api.check_image(file)
+            if result.get("flagged"):
+                warnings = await db.add_warning(app.db, message.chat.id, message.from_user.id, 10)
+                await logger.log_action(app, f"Image violation by {message.from_user.id} in {message.chat.id}")
+                if warnings >= WARNING_LIMIT:
+                    await message.chat.restrict(message.from_user.id, ChatPermissions())
+                await message.delete()

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -1,0 +1,22 @@
+from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram import filters
+
+from utils import perms, errors, db
+
+PANEL = InlineKeyboardMarkup(
+    [
+        [InlineKeyboardButton("⚙️ Settings", callback_data="settings")],
+        [InlineKeyboardButton("📘 Help", callback_data="help")],
+        [InlineKeyboardButton("👮 Admin", callback_data="admin")],
+        [InlineKeyboardButton("🔄 Refresh", callback_data="refresh")],
+    ]
+)
+
+
+def register(app):
+    @app.on_message(filters.command(["start", "help", "menu"]))
+    @errors.catch_errors
+    async def show_panel(client, message: Message):
+        if message.chat.type in ("group", "supergroup"):
+            await db.add_group(app.db, message.chat.id)
+        await message.reply_text("Control Panel", reply_markup=PANEL)

--- a/run.py
+++ b/run.py
@@ -1,0 +1,35 @@
+import asyncio
+import logging
+from pyrogram import Client
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from config import Config
+import handlers
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    app = Client(
+        "bot",
+        api_id=Config.API_ID,
+        api_hash=Config.API_HASH,
+        bot_token=Config.BOT_TOKEN,
+    )
+    app.config = Config
+    app.db = AsyncIOMotorClient(Config.MONGO_URI).bot
+
+    handlers.register_all(app)
+
+    await app.start()
+    logger.info("Bot started")
+    await idle()
+
+
+async def idle():
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,16 @@
+"""Utility modules for the bot."""
+
+from .db import (
+    get_user,
+    add_warning,
+    reset_warnings,
+    set_approved,
+    list_approved,
+    add_group,
+    get_groups,
+)
+from .perms import is_admin, is_owner
+from .errors import catch_errors
+from .formatting import safe_edit
+from .logger import log_action
+from . import api

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,41 @@
+import httpx
+from typing import Dict
+
+from config import Config
+
+
+ASYNC_CLIENT = httpx.AsyncClient()
+
+
+async def check_text_toxicity(text: str) -> float:
+    url = "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze"
+    params = {"key": Config.PERSPECTIVE_API_KEY}
+    payload = {
+        "comment": {"text": text},
+        "requestedAttributes": {"TOXICITY": {}}
+    }
+    try:
+        r = await ASYNC_CLIENT.post(url, params=params, json=payload, timeout=5)
+        r.raise_for_status()
+        score = r.json()["attributeScores"]["TOXICITY"]["summaryScore"]["value"]
+        return score * 100
+    except Exception:
+        return 0.0
+
+
+async def check_image(file_path: str) -> Dict[str, bool]:
+    url = "https://api.sightengine.com/1.0/check.json"
+    data = {
+        "models": "nudity,wad,offensive",
+        "api_user": Config.SIGHTENGINE_USER,
+        "api_secret": Config.SIGHTENGINE_SECRET,
+    }
+    try:
+        with open(file_path, "rb") as f:
+            r = await ASYNC_CLIENT.post(url, data=data, files={"media": f}, timeout=5)
+        r.raise_for_status()
+        result = r.json()
+        flagged = result.get("weapon") or result.get("alcohol") or result.get("drugs") or result.get("nudity", {}).get("safe", 1) < 0.5
+        return {"flagged": bool(flagged)}
+    except Exception:
+        return {"flagged": False}

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, List
+
+
+async def get_user(db, user_id: int) -> Dict[str, Any]:
+    user = await db.users.find_one({"_id": user_id})
+    if not user:
+        user = {"_id": user_id, "score": 0, "warnings": {}, "approved_in": []}
+        await db.users.insert_one(user)
+    return user
+
+
+async def add_warning(db, chat_id: int, user_id: int, score_delta: int = 1) -> int:
+    user = await get_user(db, user_id)
+    warnings = user.get("warnings", {})
+    key = str(chat_id)
+    warnings[key] = warnings.get(key, 0) + 1
+    user["warnings"] = warnings
+    user["score"] += score_delta
+    await db.users.update_one({"_id": user_id}, {"$set": user})
+    return warnings[key]
+
+
+async def reset_warnings(db, chat_id: int, user_id: int) -> None:
+    user = await get_user(db, user_id)
+    warnings = user.get("warnings", {})
+    warnings[str(chat_id)] = 0
+    await db.users.update_one({"_id": user_id}, {"$set": {"warnings": warnings}})
+
+
+async def set_approved(db, chat_id: int, user_id: int, value: bool) -> None:
+    user = await get_user(db, user_id)
+    approved = set(user.get("approved_in", []))
+    if value:
+        approved.add(int(chat_id))
+    else:
+        approved.discard(int(chat_id))
+    await db.users.update_one({"_id": user_id}, {"$set": {"approved_in": list(approved)}})
+
+
+async def list_approved(db, chat_id: int) -> List[int]:
+    cursor = db.users.find({"approved_in": {"$in": [int(chat_id)]}})
+    return [doc["_id"] async for doc in cursor]
+
+
+async def add_group(db, chat_id: int) -> None:
+    await db.groups.update_one({"_id": chat_id}, {"$set": {"_id": chat_id}}, upsert=True)
+
+
+async def get_groups(db) -> List[int]:
+    cursor = db.groups.find()
+    return [doc["_id"] async for doc in cursor]

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,0 +1,15 @@
+import functools
+import logging
+from pyrogram.types import Message
+
+logger = logging.getLogger(__name__)
+
+
+def catch_errors(func):
+    @functools.wraps(func)
+    async def wrapper(client, message: Message):
+        try:
+            return await func(client, message)
+        except Exception as e:
+            logger.exception("Handler error: %s", e)
+    return wrapper

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,0 +1,8 @@
+from pyrogram.types import Message
+
+
+async def safe_edit(message: Message, text: str, **kwargs):
+    try:
+        await message.edit_text(text, **kwargs)
+    except Exception:
+        pass

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,7 @@
+async def log_action(app, text: str) -> None:
+    chat_id = getattr(app.config, "LOG_CHANNEL", None)
+    if chat_id:
+        try:
+            await app.send_message(chat_id, text)
+        except Exception:
+            pass

--- a/utils/perms.py
+++ b/utils/perms.py
@@ -1,0 +1,12 @@
+from pyrogram.types import Message
+
+
+def is_owner(user_id: int, owner_id: int) -> bool:
+    return user_id == owner_id
+
+
+async def is_admin(message: Message) -> bool:
+    if not message.chat or not message.from_user:
+        return False
+    member = await message.chat.get_member(message.from_user.id)
+    return member.status in ("administrator", "creator")


### PR DESCRIPTION
## Summary
- expand Config with API keys
- implement bot startup in `run.py`
- add unified moderation handler
- add admin and broadcast commands
- include control panel and general commands
- implement MongoDB helpers and API integration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686b44618f1083298ef79dd50e521cdd