### PR TITLE
Implement AI moderation & user profiles

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,3 +5,4 @@ class Config:
     MONGO_URI = "mongodb://localhost:27017"
     LOG_CHANNEL = -1001234567890
     OWNER_ID = 123456789
+    PERSPECTIVE_API_KEY = "your_perspective_key"

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -13,5 +13,13 @@ def register(app):
             await message.reply_text("Usage: /broadcast <text>")
             return
         text = message.text.split(None, 1)[1]
-        await message.reply_text(f"Broadcasting: {text}")
-        # Placeholder for broadcast logic
+        await message.reply_text("Broadcasting...")
+        sent = 0
+        async for dialog in app.get_dialogs():
+            if dialog.chat.type in ("group", "supergroup"):
+                try:
+                    await app.send_message(dialog.chat.id, text)
+                    sent += 1
+                except Exception:
+                    continue
+        await message.reply_text(f"Broadcast sent to {sent} chats.")

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -1,14 +1,19 @@
 from pyrogram import filters
-from pyrogram.types import Message
+from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
 
-from utils import catch_errors, safe_edit
+from utils import catch_errors, safe_edit, get_or_create_user
 
 
 def register(app):
     @app.on_message(filters.command("start"))
     @catch_errors
     async def start_handler(client, message: Message):
-        await message.reply_text("Hello! I'm a moderation bot.")
+        keyboard = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Profile", callback_data="open_profile")]]
+        )
+        await message.reply_text(
+            "Hello! I'm a moderation bot.", reply_markup=keyboard
+        )
 
     @app.on_message(filters.command("help"))
     @catch_errors
@@ -19,3 +24,24 @@ def register(app):
     @catch_errors
     async def ping_handler(client, message: Message):
         await message.reply_text("Pong!")
+
+    @app.on_callback_query(filters.regex("^open_profile$"))
+    async def cb_profile(client, callback):
+        user = await get_or_create_user(app.db, callback.from_user.id)
+        text = (
+            f"**{callback.from_user.first_name}**\n"
+            f"ID: `{callback.from_user.id}`\n"
+            f"Toxicity: {user['global_toxicity_score']:.2f}\n"
+            f"Warnings: {user['warnings']}"
+        )
+        await callback.message.edit_text(
+            text,
+            reply_markup=InlineKeyboardMarkup(
+                [[InlineKeyboardButton("Close", callback_data="close")]]
+            ),
+            disable_web_page_preview=True,
+        )
+
+    @app.on_callback_query(filters.regex("^close$"))
+    async def close_cb(client, callback):
+        await callback.message.delete()

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -1,0 +1,32 @@
+from pyrogram import filters
+from pyrogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
+
+from utils import catch_errors, get_or_create_user
+
+
+def build_profile_text(user, tg_user):
+    text = [
+        f"**{tg_user.first_name}**",
+        f"ID: `{tg_user.id}`",
+        f"Toxicity: {user['global_toxicity_score']:.2f}",
+        f"Warnings: {user['warnings']}",
+        f"Approved: {'Yes' if user.get('approved') else 'No'}",
+    ]
+    return "\n".join(text)
+
+
+def register(app):
+    @app.on_message(filters.command("profile"))
+    @catch_errors
+    async def profile_handler(client, message: Message):
+        target = message.reply_to_message.from_user if message.reply_to_message else message.from_user
+        user = await get_or_create_user(app.db, target.id)
+        text = build_profile_text(user, target)
+        keyboard = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Close", callback_data="close")]]
+        )
+        await message.reply_text(text, reply_markup=keyboard, disable_web_page_preview=True)
+
+    @app.on_callback_query(filters.regex("^close$"))
+    async def close_cb(client, callback):
+        await callback.message.delete()

--- a/moderation.py
+++ b/moderation.py
@@ -1,9 +1,11 @@
 from pyrogram import filters
 from pyrogram.types import Message, ChatPermissions
 
-from utils import update_violation, catch_errors
+from utils import add_warning, catch_errors, check_toxicity
 
 BANNED_WORDS = {"badword", "hate"}
+TOXICITY_THRESHOLD = 0.8
+WARN_THRESHOLD = 3
 
 
 def register(app):
@@ -14,9 +16,16 @@ def register(app):
             return
         text = message.text.lower()
         if any(word in text for word in BANNED_WORDS):
-            user = await update_violation(app.db, message.from_user.id, 10, "warned")
-            if user["violations"] >= 3:
+            toxicity = 1.0
+        else:
+            toxicity = await check_toxicity(text)
+
+        if toxicity >= TOXICITY_THRESHOLD:
+            user = await add_warning(app.db, message.from_user.id, toxicity)
+            if user["warnings"] >= WARN_THRESHOLD:
                 await message.chat.restrict(message.from_user.id, ChatPermissions())
                 await message.reply_text("User muted for repeated violations.")
             else:
-                await message.reply_text("Please keep the chat civil.")
+                await message.reply_text(
+                    f"Toxicity {toxicity:.2f}. Please keep the chat civil."
+                )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility modules for the bot."""
 
-from .db import get_user, update_violation
+from .db import get_or_create_user, add_warning, update_violation
+from .api import check_toxicity
 from .perms import is_admin, is_owner
 from .decorators import catch_errors
 from .formatting import safe_edit

--- a/utils/api.py
+++ b/utils/api.py
@@ -1,0 +1,32 @@
+import aiohttp
+import logging
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+
+async def check_toxicity(text: str) -> float:
+    """Return Perspective API toxicity score between 0 and 1."""
+    url = "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze"
+    params = {"key": Config.PERSPECTIVE_API_KEY}
+    payload = {
+        "comment": {"text": text},
+        "languages": ["en"],
+        "requestedAttributes": {"TOXICITY": {}},
+    }
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, params=params, timeout=10) as resp:
+                data = await resp.json()
+                score = (
+                    data.get("attributeScores", {})
+                    .get("TOXICITY", {})
+                    .get("summaryScore", {})
+                    .get("value", 0.0)
+                )
+                return float(score)
+    except Exception as exc:
+        logger.error("Perspective API error: %s", exc)
+        return 0.0

--- a/utils/db.py
+++ b/utils/db.py
@@ -2,18 +2,33 @@ from datetime import datetime
 from typing import Dict, Any
 
 
-async def get_user(db, user_id: int) -> Dict[str, Any]:
+async def get_or_create_user(db, user_id: int) -> Dict[str, Any]:
     user = await db.users.find_one({"_id": user_id})
     if not user:
-        user = {"_id": user_id, "score": 0, "violations": 0, "last_action": None}
+        user = {
+            "_id": user_id,
+            "global_toxicity_score": 0.0,
+            "warnings": 0,
+            "approved": False,
+            "mutes": 0,
+            "last_violation": None,
+        }
         await db.users.insert_one(user)
     return user
 
 
-async def update_violation(db, user_id: int, score_delta: int, action: str):
-    user = await get_user(db, user_id)
-    user["score"] += score_delta
-    user["violations"] += 1
-    user["last_action"] = action
+async def add_warning(db, user_id: int, score: float) -> Dict[str, Any]:
+    user = await get_or_create_user(db, user_id)
+    user["global_toxicity_score"] += score
+    user["warnings"] += 1
+    user["last_violation"] = datetime.utcnow()
+    await db.users.replace_one({"_id": user_id}, user, upsert=True)
+    return user
+
+
+async def update_violation(db, user_id: int, score_delta: float, action: str) -> Dict[str, Any]:
+    user = await get_or_create_user(db, user_id)
+    user["global_toxicity_score"] += score_delta
+    user["last_violation"] = action
     await db.users.replace_one({"_id": user_id}, user, upsert=True)
     return user


### PR DESCRIPTION
## Summary
- add Perspective API key to config
- implement async Perspective API client
- track users in MongoDB with warnings and toxicity scores
- enforce moderation with toxicity threshold
- create `/profile` command with inline menu
- enhance `/start` to show inline profile button
- implement broadcast to all groups

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686b4931ca1c83298e048401081f6f58