### PR TITLE
Fix unknown command handler

### DIFF
--- a/handlers/general.py
+++ b/handlers/general.py
@@ -91,8 +91,9 @@ def register(app):
         await callback.answer()
         await callback.message.delete()
 
-    @app.on_message(filters.command() & filters.private, group=1)
+    @app.on_message(filters.regex("^/") & filters.private, group=1)
     async def unknown(client, message: Message):
-        if message.command[0].lower() in COMMANDS:
+        command = message.text.split()[0][1:].split("@")[0].lower()
+        if command in COMMANDS:
             return
         await message.reply_text("Unknown command. Use /help.")


### PR DESCRIPTION
## Summary
- fix the filters in `handlers/general.py` so the bot no longer crashes when catching unknown commands

## Testing
- `python -m pip install -r requirements.txt`
- `timeout 5s python -m run` *(interrupted after confirming startup logs)*

------
https://chatgpt.com/codex/tasks/task_b_686ba4e0192883298e7139a6f1e0c2ca