### PR TITLE
Set log level to info

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,7 +13,7 @@ import moderation
 from database import init_db
 from config import Config
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- tone down bot logs by using `logging.INFO`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686bcd1539d4832997d3b78ca01797cb