### PR TITLE
Improve startup flow and logging

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -94,3 +94,5 @@ def register(app):
         await app.db.commit()
         await message.reply_text(f"✅ Cleared all warnings for [user](tg://user?id={user_id}).", disable_web_page_preview=True)
         logger.info("Cleared warnings for %s via %s", user_id, message.from_user.id)
+
+    logger.info("✅ Admin handlers registered.")

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -191,3 +191,5 @@ def register(app):
                 "❌ Unknown command. Use /help to see available options."
             )
 
+    logger.info("✅ Start handlers registered.")
+

--- a/run.py
+++ b/run.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import sys
@@ -61,16 +60,14 @@ async def main():
     moderation.register(app)
     logger.info("✅ Handlers and moderation system registered.")
 
-    async with app:
-        logger.info("🤖 Bot is now running.")
-        await idle()
+    await idle()
 
     await db.close()
 
 if __name__ == "__main__":
     try:
         logger.info("🔧 Launching bot process...")
-        asyncio.run(main())
+        app.run(main())
     except (KeyboardInterrupt, SystemExit):
         logger.warning("⚠️ Bot shutdown via keyboard or system exit.")
     except Exception as e:


### PR DESCRIPTION
## Summary
- refactor run loop to use `Client.run()`
- log when start and admin handlers finish registration

## Testing
- `python -m py_compile run.py handlers/*.py helpers/*.py database/*.py moderation.py config.py`
- `python predeploy.py` *(fails: Missing required env var: BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_b_686cc3ff77e48329a5bd3cb1b67d8a4c