### PR TITLE
Fix render service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo systemctl start pingbot
 ```
 
 ### Render.com
-Create a new Web Service pointing to this repository. Render uses `render.yaml` for configuration. Render defaults to the latest Python version which may be incompatible with pinned dependencies. This project targets **Python 3.11**, so the repository includes a `runtime.txt` and `.python-version` file to explicitly set the Python version during deployment.
+Create a new **Background Worker** pointing to this repository. Render uses `render.yaml` for configuration. Render defaults to the latest Python version which may be incompatible with pinned dependencies. This project targets **Python 3.11**, so the repository includes a `runtime.txt` and `.python-version` file to explicitly set the Python version during deployment.
 `render.yaml` installs packages using the `--only-binary=:all:` flag to ensure pre-built wheels.
 ## API Keys
 - [Perspective API](https://www.perspectiveapi.com/) for toxicity detection

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 services:
-  - type: web
+  - type: worker
     name: telegram-moderation-bot
     env: python
     plan: free


### PR DESCRIPTION
## Summary
- update Render deployment config to use a worker service
- clarify README instructions for Render deployment

## Testing
- `pip install -r requirements.txt`
- `python predeploy.py` *(fails: Missing required env var BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_b_686cc827dcbc8329ac4637c0a6673d9a