### PR TITLE
Fix idle call for Pyrogram v2

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@ import pkg_resources
 from PIL import __version__ as PIL_VERSION
 
 import aiosqlite
-from pyrogram import Client
+from pyrogram import Client, idle
 
 import handlers
 import moderation
@@ -62,7 +62,7 @@ async def main():
 
     async with app:
         logger.info("🤖 Bot started. Waiting for updates...")
-        await app.idle()
+        await idle()
 
     await db.close()
     logger.info("📴 Database connection closed.")


### PR DESCRIPTION
## Summary
- use `pyrogram.idle` instead of missing `Client.idle`

## Testing
- `pip install -q -r requirements.txt`
- `python predeploy.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_b_686d26c5fc888329af7751cd0556c534