### PR TITLE
Add debug logging hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Edit `.env` with the following keys:
 - `PERSPECTIVE_API_KEY` – Google Perspective API key
 - `IMAGE_MOD_API_KEY` – Sightengine credentials `user:secret`
 - `DB_FILE` – path to the SQLite DB file. By default the value of `DATABASE_URL` is used unless it looks like a Postgres connection string. This avoids issues with hosts like Render that automatically define `DATABASE_URL` for Postgres.
+- `DEBUG_UPDATES` – set to `1` to enable verbose logging of every incoming update. Useful when troubleshooting why the bot is not receiving commands.

--- a/handlers/debug.py
+++ b/handlers/debug.py
@@ -1,0 +1,18 @@
+import logging
+from pyrogram import filters
+from pyrogram.types import Update
+
+logger = logging.getLogger(__name__)
+
+def register(app):
+    """Debug handlers that log every incoming update."""
+
+    @app.on_message(filters.all)
+    async def log_message(client, message):
+        user = message.from_user.id if message.from_user else 'unknown'
+        text = message.text or message.caption or ''
+        logger.info("Message from %s in %s: %s", user, message.chat.id, text)
+
+    @app.on_raw_update()
+    async def log_raw(client, update: Update, users, chats):
+        logger.debug("RAW UPDATE: %r", update)

--- a/run.py
+++ b/run.py
@@ -60,6 +60,14 @@ async def main():
     moderation.register(app)
     logger.info("✅ Handlers and moderation system registered.")
 
+    if os.getenv("DEBUG_UPDATES"):
+        try:
+            from handlers import debug as debug_handlers
+            debug_handlers.register(app)
+            logger.info("🐞 Debug handlers enabled.")
+        except Exception as e:
+            logger.exception("Failed to register debug handlers: %s", e)
+
     async with app:
         logger.info("🤖 Bot started. Waiting for updates...")
         await idle()


### PR DESCRIPTION
## Summary
- add new `debug` handler module to log all incoming messages and raw updates
- allow enabling debug handlers via `DEBUG_UPDATES` env var
- document the `DEBUG_UPDATES` variable

## Testing
- `python -m predeploy` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_686d4cd7e3e083299043ee3dae5474b1