### PR TITLE
Add MTProto troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,15 @@ Edit `.env` with the following keys:
 - `IMAGE_MOD_API_KEY` – Sightengine credentials `user:secret`
 - `DB_FILE` – path to the SQLite DB file. By default the value of `DATABASE_URL` is used unless it looks like a Postgres connection string. This avoids issues with hosts like Render that automatically define `DATABASE_URL` for Postgres.
 - `DEBUG_UPDATES` – set to `1` to enable verbose logging of every incoming update. Useful when troubleshooting why the bot is not receiving commands.
+
+## Troubleshooting MTProto connectivity on Render
+
+Some hosts may block or throttle Telegram's MTProto ports. To verify long polling works on your Render worker, run the following minimal script:
+
+```bash
+python mtproto_test.py
+```
+
+If the bot sends a startup message and responds to commands, MTProto is allowed. Otherwise, consider switching to HTTP-based polling using `python-telegram-bot` or `aiogram`.
+
+A basic HTTP polling example using `python-telegram-bot` is available in `http_polling_example.py`.

--- a/http_polling_example.py
+++ b/http_polling_example.py
@@ -1,0 +1,16 @@
+"""Simple HTTP polling bot using python-telegram-bot."""
+import os
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Hello from HTTP polling bot!")
+
+def main():
+    token = os.getenv("BOT_TOKEN")
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(CommandHandler("start", start))
+    application.run_polling()
+
+if __name__ == "__main__":
+    main()

--- a/mtproto_test.py
+++ b/mtproto_test.py
@@ -1,0 +1,12 @@
+# Minimal script to test MTProto long polling on Render
+import asyncio
+import os
+from pyrogram import Client, idle
+
+async def main():
+    async with Client('test', bot_token=os.getenv('BOT_TOKEN'), api_id=int(os.getenv('API_ID')), api_hash=os.getenv('API_HASH')) as app:
+        await app.send_message(os.getenv('OWNER_ID'), 'Bot started via MTProto long polling.')
+        await idle()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- document how to verify MTProto long polling
- provide simple test script for Pyrogram
- add example for HTTP polling with python-telegram-bot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d53aeb31c8329ae65e4352463eb0b