### PR TITLE
Fix command handlers not responding

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -5,7 +5,6 @@ from pyrogram.types import Message
 logger = logging.getLogger(__name__)
 
 from helpers import (
-    catch_errors,
     get_or_create_user,
     is_admin,
     approve_user,
@@ -15,7 +14,6 @@ from config import Config
 
 def register(app):
     @app.on_message(filters.command("broadcast") & filters.user(Config.OWNER_ID))
-    @catch_errors
     async def broadcast_handler(client, message: Message):
         print("Received /broadcast command")
         logger.info("/broadcast by %s", message.from_user.id)
@@ -36,7 +34,6 @@ def register(app):
         await message.reply_text(f"✅ Broadcast sent to `{sent}` chats.")
 
     @app.on_message(filters.command("approve"))
-    @catch_errors
     async def approve_handler(client, message: Message):
         print("Received /approve command")
         if not await is_admin(message):
@@ -51,7 +48,6 @@ def register(app):
         logger.info("Approved user %s via %s", user_id, message.from_user.id)
 
     @app.on_message(filters.command("unapprove"))
-    @catch_errors
     async def unapprove_handler(client, message: Message):
         print("Received /unapprove command")
         if not await is_admin(message):
@@ -66,7 +62,6 @@ def register(app):
         logger.info("Unapproved user %s via %s", user_id, message.from_user.id)
 
     @app.on_message(filters.command("approved"))
-    @catch_errors
     async def approved_list(client, message: Message):
         print("Received /approved command")
         if not await is_admin(message):
@@ -84,7 +79,6 @@ def register(app):
         logger.info("Listed approved users for %s", message.from_user.id)
 
     @app.on_message(filters.command("rmwarn"))
-    @catch_errors
     async def rmwarn_handler(client, message: Message):
         print("Received /rmwarn command")
         if not await is_admin(message):

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -8,11 +8,12 @@ from pyrogram.types import (
     InputMediaPhoto,
 )
 
-from helpers import catch_errors, get_or_create_user
+from helpers import get_or_create_user
 
 logger = logging.getLogger(__name__)
 
 def register(app):
+    print("start.register called")
     def main_menu() -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup(
             [
@@ -29,9 +30,9 @@ def register(app):
         "approve", "unapprove", "approved", "rmwarn", "broadcast",
     }
 
-    @app.on_message(filters.command(["start", "menu", "help"]) & (filters.private | filters.group))
-    @catch_errors
+    @app.on_message(filters.command(["start", "menu", "help"]))
     async def start_handler(client, message: Message):
+        print("handler triggered")
         print(f"🟢 Received /{message.command[0]} from {message.from_user.id} in chat {message.chat.id}")
         logger.info("Command %s from %s in %s", message.command[0].lower(), message.from_user.id, message.chat.id)
         await message.reply_text(
@@ -41,15 +42,14 @@ def register(app):
             disable_web_page_preview=True,
         )
 
-    @app.on_message(filters.command("ping") & (filters.private | filters.group))
-    @catch_errors
+    @app.on_message(filters.command("ping"))
     async def ping_handler(client, message: Message):
+        print("handler triggered")
         print(f"🟢 /ping received from {message.from_user.id} in chat {message.chat.id}")
         logger.info("/ping by %s in %s", message.from_user.id, message.chat.id)
         await message.reply_text("🏓 Pong!")
 
-    @app.on_message(filters.command("profile") & (filters.private | filters.group))
-    @catch_errors
+    @app.on_message(filters.command("profile"))
     async def profile_handler(client, message: Message):
         print(f"🟢 /profile received from {message.from_user.id}")
         logger.info("/profile by %s in %s", message.from_user.id, message.chat.id)
@@ -155,7 +155,7 @@ def register(app):
         await callback.message.delete()
 
     # Unknown command fallback
-    @app.on_message(filters.regex("^/") & filters.private, group=999)
+    @app.on_message(filters.regex("^/"), group=999)
     async def unknown(client, message: Message):
         command = message.text.split()[0][1:].split("@")[0].lower()
         if command not in COMMANDS:

--- a/moderation.py
+++ b/moderation.py
@@ -7,7 +7,6 @@ from config import Config
 from helpers import (
     add_warning,
     add_log,
-    catch_errors,
     check_image,
     check_toxicity,
     get_or_create_user,
@@ -65,8 +64,7 @@ async def process_violation(client, message: Message, user_id: int, score: float
 
 def register(app):
     # Ignore commands and service messages in moderation
-    @app.on_message(~filters.service & ~filters.command(SAFE_COMMANDS), group=1)
-    @catch_errors
+    @app.on_message(~filters.service & ~filters.command(SAFE_COMMANDS))
     async def moderate_messages(client, message: Message):
         if not message.from_user or message.from_user.is_self:
             return


### PR DESCRIPTION
## Summary
- show when `register` is called for start handlers
- drop privacy filters and error wrappers from command handlers
- remove group=1 usage in moderation
- add debug print inside `/start` and `/ping` handlers

## Testing
- `pip install -r requirements.txt`
- `python -m run` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_686eb5b8d014832989667a4e51522a85