### PR TITLE
Refactor bot for Application.run_polling

### DIFF
--- a/handlers/debug.py
+++ b/handlers/debug.py
@@ -1,18 +1,23 @@
 import logging
-from pyrogram import filters
-from pyrogram.types import Update
+from telegram import Update
+from telegram.ext import Application, MessageHandler, ContextTypes, TypeHandler, filters
 
 logger = logging.getLogger(__name__)
 
-def register(app):
+def register(app: Application):
     """Debug handlers that log every incoming update."""
 
-    @app.on_message(filters.all)
-    async def log_message(client, message):
-        user = message.from_user.id if message.from_user else 'unknown'
-        text = message.text or message.caption or ''
-        logger.info("Message from %s in %s: %s", user, message.chat.id, text)
+    async def log_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        message = update.effective_message
+        if not message:
+            return
+        user = update.effective_user.id if update.effective_user else "unknown"
+        text = message.text or message.caption or ""
+        logger.info("Message from %s in %s: %s", user, update.effective_chat.id, text)
 
-    @app.on_raw_update()
-    async def log_raw(client, update: Update, users, chats):
+    async def log_raw(update: Update, context: ContextTypes.DEFAULT_TYPE):
         logger.debug("RAW UPDATE: %r", update)
+
+    app.add_handler(MessageHandler(filters.ALL, log_message))
+    app.add_handler(TypeHandler(Update, log_raw))
+

--- a/helpers/decorators.py
+++ b/helpers/decorators.py
@@ -1,23 +1,24 @@
 import functools
 import logging
 from contextlib import suppress
-from pyrogram.types import Message
-from pyrogram.client import Client
+from telegram import Update
+from telegram.ext import ContextTypes
 
 logger = logging.getLogger(__name__)
 
 def catch_errors(func):
     """
-    Decorator for safely catching and logging exceptions in async Pyrogram handlers.
+    Decorator for safely catching and logging exceptions in async handlers.
     """
     @functools.wraps(func)
-    async def wrapper(client: Client, *args, **kwargs):
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
         try:
-            return await func(client, *args, **kwargs)
+            return await func(update, context, *args, **kwargs)
         except Exception as e:
-            logger.exception(f"❌ Error in handler {func.__name__}: {e}")
+            logger.exception("❌ Error in handler %s: %s", func.__name__, e)
             # Optional: You can also notify in dev channel or reply in chat
-            if args and isinstance(args[0], Message):
+            if update.message:
                 with suppress(Exception):
-                    await args[0].reply_text("⚠️ An internal error occurred. Please try again later.")
+                    await update.message.reply_text("⚠️ An internal error occurred. Please try again later.")
     return wrapper
+

--- a/helpers/formatting.py
+++ b/helpers/formatting.py
@@ -1,5 +1,5 @@
 import logging
-from pyrogram.types import Message
+from telegram import Message
 
 logger = logging.getLogger(__name__)
 
@@ -11,3 +11,4 @@ async def safe_edit(message: Message, text: str, **kwargs):
         await message.edit_text(text, **kwargs)
     except Exception as e:
         logger.warning("❗ Failed to edit message %s: %s", message.id, e)
+

--- a/helpers/perms.py
+++ b/helpers/perms.py
@@ -1,6 +1,6 @@
 import logging
-from pyrogram.types import Message
-from pyrogram.enums import ChatMemberStatus
+from telegram import Message
+from telegram.constants import ChatMemberStatus
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ async def is_admin(message: Message) -> bool:
         member = await message.chat.get_member(message.from_user.id)
         return member.status in (
             ChatMemberStatus.ADMINISTRATOR,
-            ChatMemberStatus.OWNER  # or .CREATOR depending on Pyrogram version
+            ChatMemberStatus.OWNER,
         )
     except Exception as e:
         logger.warning("⚠️ Failed to check admin status for user %s: %s", message.from_user.id, e)

--- a/moderation.py
+++ b/moderation.py
@@ -1,7 +1,13 @@
 import logging
-from pyrogram import filters
-from pyrogram.enums import ChatMemberStatus, ParseMode
-from pyrogram.types import Message, ChatMemberUpdated, ChatPermissions
+from telegram import Update, ChatPermissions
+from telegram.constants import ChatMemberStatus, ParseMode
+from telegram.ext import (
+    Application,
+    MessageHandler,
+    ChatMemberHandler,
+    ContextTypes,
+    filters,
+)
 
 from config import Config
 from helpers import (
@@ -24,7 +30,7 @@ SAFE_COMMANDS = [
     "approve", "unapprove", "broadcast"
 ]
 
-async def process_violation(client, message: Message, user_id: int, score: float, reason: str):
+async def process_violation(application: Application, message, user_id: int, score: float, reason: str):
     logger.warning("🔴 Violation Detected | Reason: %s | Score: %.2f | User: %d", reason, score, user_id)
 
     try:
@@ -32,45 +38,45 @@ async def process_violation(client, message: Message, user_id: int, score: float
     except Exception as e:
         logger.error("Failed to delete message: %s", e)
 
-    user = await add_warning(client.db, user_id, score)
-    await add_log(client.db, user_id, message.chat.id, reason, score)
+    user = await add_warning(application.db, user_id, score)
+    await add_log(application.db, user_id, message.chat.id, reason, score)
 
     if user["warnings"] >= WARN_THRESHOLD:
         try:
-            await message.chat.restrict(user_id, ChatPermissions())
-            await client.send_message(
+            await application.bot.restrict_chat_member(message.chat.id, user_id, ChatPermissions())
+            await application.bot.send_message(
                 message.chat.id,
                 f"🔇 <b>User {user_id} has been muted for repeated {reason} violations.</b>",
-                parse_mode=ParseMode.HTML
+                parse_mode=ParseMode.HTML,
             )
         except Exception:
             logger.exception("Failed to mute user")
     else:
-        await client.send_message(
+        await application.bot.send_message(
             message.chat.id,
             f"⚠️ <b>Warning issued for {reason}</b>\nTotal warnings: <code>{user['warnings']}</code>",
-            parse_mode=ParseMode.HTML
+            parse_mode=ParseMode.HTML,
         )
 
     if Config.LOG_CHANNEL:
         try:
-            await client.send_message(
+            await application.bot.send_message(
                 Config.LOG_CHANNEL,
                 f"📛 Violation Log:\n<b>User:</b> <code>{user_id}</code>\n<b>Chat:</b> <code>{message.chat.id}</code>\n<b>Reason:</b> {reason}\n<b>Score:</b> {score}",
-                parse_mode=ParseMode.HTML
+                parse_mode=ParseMode.HTML,
             )
         except Exception:
             logger.warning("Could not send log to LOG_CHANNEL")
 
-def register(app):
+def register(app: Application):
     # Ignore commands and service messages in moderation
-    @app.on_message(~filters.service & ~filters.command(SAFE_COMMANDS))
-    async def moderate_messages(client, message: Message):
-        if not message.from_user or message.from_user.is_self:
+    async def moderate_messages(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        message = update.effective_message
+        if not message or not update.effective_user:
             return
 
-        user_id = message.from_user.id
-        chat_id = message.chat.id
+        user_id = update.effective_user.id
+        chat_id = update.effective_chat.id
 
         if user_id == Config.OWNER_ID or await is_admin(message):
             return
@@ -83,7 +89,7 @@ def register(app):
         if text:
             score = await check_toxicity(text)
             if score >= TOXICITY_THRESHOLD:
-                await process_violation(client, message, user_id, score, "toxicity")
+                await process_violation(context.application, message, user_id, score, "toxicity")
                 return
 
         media = None
@@ -99,18 +105,20 @@ def register(app):
             media = message.document.file_id
 
         if media:
-            file = await client.download_media(media, in_memory=True)
+            file = await context.bot.get_file(media)
+            file = await file.download_as_bytearray()
             result = await check_image(file)
             nudity = result.get("nudity", {}).get("sexual_activity", 0)
             drugs = result.get("drug", 0)
             score = max(nudity, drugs)
             if score >= NSFW_THRESHOLD:
-                await process_violation(client, message, user_id, score, "nsfw")
+                await process_violation(context.application, message, user_id, score, "nsfw")
 
-    @app.on_chat_member_updated()
-    async def check_new_member(client, chat_member: ChatMemberUpdated):
+    async def check_new_member(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        chat_member = update.chat_member
         if chat_member.new_chat_member.status not in {
-            ChatMemberStatus.MEMBER, ChatMemberStatus.RESTRICTED
+            ChatMemberStatus.MEMBER,
+            ChatMemberStatus.RESTRICTED,
         }:
             return
 
@@ -123,13 +131,16 @@ def register(app):
 
         if user["warnings"] >= WARN_THRESHOLD:
             try:
-                await client.restrict_chat_member(chat_id, user_id, ChatPermissions())
-                await client.send_message(
+                await context.bot.restrict_chat_member(chat_id, user_id, ChatPermissions())
+                await context.bot.send_message(
                     chat_id,
                     f"🔇 <b>{chat_member.from_user.mention} was muted on join due to past violations.</b>",
-                    parse_mode=ParseMode.HTML
+                    parse_mode=ParseMode.HTML,
                 )
             except Exception:
                 logger.exception("Failed to restrict user on join")
+
+    app.add_handler(MessageHandler(~filters.StatusUpdate.ALL, moderate_messages))
+    app.add_handler(ChatMemberHandler(check_new_member, ChatMemberHandler.CHAT_MEMBER))
 
     logger.info("✅ Moderation handlers registered successfully.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-telegram-bot==20.8
 pyrogram==2.0.106
 aiohttp==3.9.4
 aiosqlite==0.19.0


### PR DESCRIPTION
## Summary
- refactor run.py to use python-telegram-bot `Application`
- update handler modules to register CommandHandler and CallbackQueryHandler
- convert helper utilities and moderation logic for telegram.ext
- keep pyrogram dependency for optional scripts

## Testing
- `python -m py_compile run.py handlers/*.py moderation.py helpers/*.py`

------
https://chatgpt.com/codex/tasks/task_b_686f6aca77b88329a54489e8cae440ae