### PR TITLE
Fix build by aligning httpx with python-telegram-bot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pyrogram==2.0.106
 aiohttp==3.9.4
 aiosqlite==0.19.0
 python-dotenv==1.0.0
-httpx==0.27.0
+httpx==0.26.0
 pillow==9.5.0  # Avoid 10.x for now


### PR DESCRIPTION
## Summary
- pin `httpx` to 0.26.x so it satisfies python‑telegram‑bot's requirement

## Testing
- `pip install -r requirements.txt -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_686f6d6bde1883298f34bd7767b3f867