### PR TITLE
Fix SQLite path creation

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import aiosqlite
 from telegram.ext import ApplicationBuilder
 
@@ -11,7 +12,13 @@ from moderation import register as register_moderation
 
 
 async def post_init(application):
-    application.db = await aiosqlite.connect(Config.DATABASE_URL)
+    db_url = Config.DATABASE_URL
+    if "://" not in db_url and db_url not in ("", ":memory:"):
+        db_dir = os.path.dirname(db_url)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
+    application.db = await aiosqlite.connect(db_url)
     await init_db(application.db)
 
 


### PR DESCRIPTION
## Summary
- ensure sqlite DB directory exists before connecting

## Testing
- `pip install -r requirements.txt`
- `python predeploy.py` *(fails: Missing required env var `BOT_TOKEN`)*

------
https://chatgpt.com/codex/tasks/task_b_686f6ebf74008329bb6737c2d2d88af5