### PR TITLE
Handle sqlite file URI database URLs

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from urllib.parse import urlparse, unquote
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -32,6 +33,7 @@ class Config:
     # DATABASE_URL if provided and looks like a file path.
     _db_file = os.getenv("DB_FILE")
     _db_url = os.getenv("DATABASE_URL", "bot.db")
+
     if _db_file:
         DATABASE_URL = _db_file
     elif _db_url.startswith("postgres://") or _db_url.startswith("postgresql://"):
@@ -41,6 +43,10 @@ class Config:
             _db_url,
         )
         DATABASE_URL = "bot.db"
+    elif _db_url.startswith("sqlite:"):
+        parsed = urlparse(_db_url)
+        path = unquote(parsed.path or parsed.netloc)
+        DATABASE_URL = f"file:{path}?{parsed.query}" if parsed.query else path
     else:
         DATABASE_URL = _db_url
 

--- a/run.py
+++ b/run.py
@@ -18,7 +18,8 @@ async def post_init(application):
         if db_dir:
             os.makedirs(db_dir, exist_ok=True)
 
-    application.db = await aiosqlite.connect(db_url)
+    uri = db_url.startswith("file:")
+    application.db = await aiosqlite.connect(db_url, uri=uri)
     await init_db(application.db)
 
 


### PR DESCRIPTION
## Summary
- support SQLite URLs starting with `sqlite:` or `file:`
- open SQLite connections with `uri=True` when using file URIs

## Testing
- `python predeploy.py` *(fails: Missing required env var: BOT_TOKEN)*
- `BOT_TOKEN=1 API_ID=1 API_HASH=a python -m run` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686f708d3f50832982953381a2f8eef0