### PR TITLE
Fix back button error and add panel image option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ LOG_CHANNEL_ID=-1001234567890
 PERSPECTIVE_API_KEY=your_perspective_key
 IMAGE_MOD_API_KEY=user:secret
 DB_FILE=bot.db
+PANEL_IMAGE=https://example.com/panel.jpg

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ A modular Telegram bot built with **Pyrogram** for automated AI-powered moderati
 - `/approve` `/unapprove` `/approved` `/rmwarn` – admin tools
 - `/broadcast <text>` – owner broadcast
 
+## Usage
+1. Start the bot in a private chat or add it to a group.
+2. Use `/menu` to open the control panel. If `PANEL_IMAGE` is configured, the panel is shown with the image you provide.
+3. Explore the inline buttons to view your profile, configure groups or broadcast messages.
+
 ## Setup
 1. Install **Python 3.11** and create a virtual environment (optional).
 2. Copy `.env.example` to `.env` and fill the values.
@@ -50,6 +55,7 @@ Edit `.env` with the following keys:
 - `PERSPECTIVE_API_KEY` – Google Perspective API key
 - `IMAGE_MOD_API_KEY` – Sightengine credentials `user:secret`
 - `DB_FILE` – path to the SQLite DB file. By default the value of `DATABASE_URL` is used unless it looks like a Postgres connection string. This avoids issues with hosts like Render that automatically define `DATABASE_URL` for Postgres.
+- `PANEL_IMAGE` – optional URL or file path to an image shown with the control panel.
 - `DEBUG_UPDATES` – set to `1` to enable verbose logging of every incoming update. Useful when troubleshooting why the bot is not receiving commands.
 
 ## Troubleshooting MTProto connectivity on Render

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config:
 
     PERSPECTIVE_API_KEY = os.getenv("PERSPECTIVE_API_KEY", "")
     IMAGE_MOD_API_KEY = os.getenv("IMAGE_MOD_API_KEY", "")
+    PANEL_IMAGE = os.getenv("PANEL_IMAGE")
 
     # Prefer DB_FILE to avoid clashing with hosting providers that predefine
     # DATABASE_URL for Postgres connections (e.g. Render.com). Fallback to

--- a/run.py
+++ b/run.py
@@ -42,6 +42,7 @@ def main() -> None:
         .post_init(post_init)
         .build()
     )
+    application.config = Config
 
     register_start(application)
     register_admin(application)


### PR DESCRIPTION
## Summary
- allow showing a start panel image with `PANEL_IMAGE`
- improve help text layout and group settings message
- handle `back_home` callback when last message has no text
- document new option in README and `.env.example`

## Testing
- `python -m py_compile handlers/start.py run.py config.py`

------
https://chatgpt.com/codex/tasks/task_b_686fd44e17288329b8707fa73addf0dd