### PR TITLE
Improve logging and group tracking

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -27,6 +27,17 @@ async def init_db(db: aiosqlite.Connection):
             timestamp TEXT
         )
     """)
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS groups (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            username TEXT,
+            members INTEGER DEFAULT 0,
+            link TEXT
+        )
+    """
+    )
     await db.commit()
 
 
@@ -96,4 +107,34 @@ async def add_log(db: aiosqlite.Connection, user_id: int, chat_id: int, reason: 
         INSERT INTO logs (user_id, chat_id, reason, score, timestamp)
         VALUES (?, ?, ?, ?, ?)
     """, (user_id, chat_id, reason, score, datetime.utcnow().isoformat()))
+    await db.commit()
+
+
+async def upsert_group(
+    db: aiosqlite.Connection,
+    chat_id: int,
+    title: str,
+    username: str | None = None,
+    members: int = 0,
+    link: str | None = None,
+) -> None:
+    """Insert or update a group entry."""
+    await db.execute(
+        """
+        INSERT INTO groups (id, title, username, members, link)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            title=excluded.title,
+            username=excluded.username,
+            members=excluded.members,
+            link=excluded.link
+        """,
+        (chat_id, title, username, members, link),
+    )
+    await db.commit()
+
+
+async def remove_group(db: aiosqlite.Connection, chat_id: int) -> None:
+    """Remove a group from the database."""
+    await db.execute("DELETE FROM groups WHERE id=?", (chat_id,))
     await db.commit()

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -8,6 +8,8 @@ from database import (
     add_warning,
     approve_user,
     add_log,
+    upsert_group,
+    remove_group,
 )
 
 from .api import (
@@ -28,6 +30,8 @@ __all__ = [
     "add_warning",
     "approve_user",
     "add_log",
+    "upsert_group",
+    "remove_group",
     "check_toxicity",
     "check_image",
     "is_admin",

--- a/helpers/api.py
+++ b/helpers/api.py
@@ -1,11 +1,13 @@
 import aiohttp
 import logging
 from config import Config
+from telegram.constants import ParseMode
+import html
 
 logger = logging.getLogger(__name__)
 
 
-async def check_toxicity(text: str) -> float:
+async def check_toxicity(text: str, bot=None) -> float:
     """
     Analyze the toxicity score of a given text using the Perspective API.
     Returns a float score between 0 (clean) and 1 (toxic).
@@ -24,7 +26,13 @@ async def check_toxicity(text: str) -> float:
         async with aiohttp.ClientSession() as session:
             async with session.post(url, json=payload, params=params, timeout=10) as resp:
                 if resp.status != 200:
-                    logger.error("Perspective API returned status %s", resp.status)
+                    msg = f"🚨 Perspective API error {resp.status}"
+                    logger.error(msg)
+                    if bot and Config.LOG_CHANNEL:
+                        try:
+                            await bot.send_message(Config.LOG_CHANNEL, msg)
+                        except Exception:
+                            pass
                     return 0.0
                 data = await resp.json()
                 score = (
@@ -37,13 +45,23 @@ async def check_toxicity(text: str) -> float:
                 return float(score)
     except aiohttp.ClientError as exc:
         logger.error("🌐 Perspective API connection error: %s", exc)
+        if bot and Config.LOG_CHANNEL:
+            try:
+                await bot.send_message(Config.LOG_CHANNEL, f"Perspective API error: {exc}")
+            except Exception:
+                pass
     except Exception as exc:
         logger.exception("Unexpected error in toxicity check: %s", exc)
+        if bot and Config.LOG_CHANNEL:
+            try:
+                await bot.send_message(Config.LOG_CHANNEL, f"Perspective API exception: {html.escape(str(exc))}", parse_mode=ParseMode.HTML)
+            except Exception:
+                pass
 
     return 0.0
 
 
-async def check_image(file: bytes) -> dict:
+async def check_image(file: bytes, bot=None) -> dict:
     """
     Analyze an image using Sightengine API for NSFW, drugs, and weapons detection.
     Returns a dictionary with model probabilities.
@@ -64,14 +82,30 @@ async def check_image(file: bytes) -> dict:
         async with aiohttp.ClientSession() as session:
             async with session.post(url, data=data, params=params, timeout=10) as resp:
                 if resp.status != 200:
-                    logger.error("Sightengine API returned status %s", resp.status)
+                    msg = f"🚨 Sightengine API error {resp.status}"
+                    logger.error(msg)
+                    if bot and Config.LOG_CHANNEL:
+                        try:
+                            await bot.send_message(Config.LOG_CHANNEL, msg)
+                        except Exception:
+                            pass
                     return {}
                 result = await resp.json()
                 logger.debug("✅ Sightengine response: %s", result)
                 return result
     except aiohttp.ClientError as exc:
         logger.error("🌐 Sightengine API connection error: %s", exc)
+        if bot and Config.LOG_CHANNEL:
+            try:
+                await bot.send_message(Config.LOG_CHANNEL, f"Sightengine error: {exc}")
+            except Exception:
+                pass
     except Exception as exc:
         logger.exception("Unexpected error in image check: %s", exc)
+        if bot and Config.LOG_CHANNEL:
+            try:
+                await bot.send_message(Config.LOG_CHANNEL, f"Sightengine exception: {html.escape(str(exc))}", parse_mode=ParseMode.HTML)
+            except Exception:
+                pass
 
     return {}

--- a/moderation.py
+++ b/moderation.py
@@ -87,7 +87,7 @@ def register(app: Application):
 
         text = message.text or message.caption
         if text:
-            score = await check_toxicity(text)
+            score = await check_toxicity(text, context.bot)
             if score >= TOXICITY_THRESHOLD:
                 await process_violation(context.application, message, user_id, score, "toxicity")
                 return
@@ -107,7 +107,7 @@ def register(app: Application):
         if media:
             file = await context.bot.get_file(media)
             file = await file.download_as_bytearray()
-            result = await check_image(file)
+            result = await check_image(file, context.bot)
             nudity = result.get("nudity", {}).get("sexual_activity", 0)
             drugs = result.get("drug", 0)
             score = max(nudity, drugs)


### PR DESCRIPTION
## Summary
- track users & groups in the database
- log DM `/start` events and bot join/leave events
- report moderation API errors to log group
- show first name in panel and simplify `/profile`
- wrap callbacks with error handler

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python mtproto_test.py` *(fails: API_ID/BOT_TOKEN unset)*

------
https://chatgpt.com/codex/tasks/task_b_686fe3137fc48329bdd8d652cbc9ed3d