### PR TITLE
Improve moderation with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modular Telegram bot built with **Pyrogram** for automated AI-powered moderati
 - `/ping` – check bot status
 - `/approve` `/unapprove` `/approved` `/rmwarn` – admin tools
 - `/broadcast <text>` – owner broadcast
+- `/modcheck` – test moderation API
 
 ## Usage
 1. Start the bot in a private chat or add it to a group.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiosqlite==0.19.0
 python-dotenv==1.0.0
 httpx==0.26.0
 pillow==9.5.0  # Avoid 10.x for now
+requests==2.32.3


### PR DESCRIPTION
## Summary
- use Safone moderation API for text filtering
- expose `/modcheck` command for owners
- add requests dependency
- document new command

## Testing
- `python -m predeploy` *(fails: Missing required env var: BOT_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_b_686fe7d641f48329a3f8e3fe335bc20f