### PR TITLE
Handle repeated help edits

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -160,13 +160,17 @@ def register(app: Application):
             "• `/rmwarn` - Reset warnings\n"
             "• `/start`, `/menu`, `/help` - Show control panel"
         )
-        await query.message.edit_text(
-            help_text,
-            reply_markup=InlineKeyboardMarkup(
-                [[InlineKeyboardButton("🔙 Back to Menu", callback_data="back_home")]]
-            ),
-            disable_web_page_preview=True,
-        )
+        try:
+            await query.message.edit_text(
+                help_text,
+                reply_markup=InlineKeyboardMarkup(
+                    [[InlineKeyboardButton("🔙 Back to Menu", callback_data="back_home")]]
+                ),
+                disable_web_page_preview=True,
+            )
+        except BadRequest as e:
+            if "Message is not modified" not in str(e):
+                raise
 
     @catch_errors
     async def cb_settings(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary
- handle BadRequest when help message isn't modified

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686feb4d675c8329bfcb6682493636d0