### PR TITLE
Replace moderation API with DeepAI toxicity check

### DIFF
--- a/moderation.py
+++ b/moderation.py
@@ -16,14 +16,13 @@ from helpers import (
     add_warning,
     add_log,
     check_image,
-    check_toxicity,
     get_or_create_user,
     is_admin,
 )
 
 logger = logging.getLogger(__name__)
 
-MOD_API_URL = Config.MOD_API_URL
+MOD_API_URL = "https://api.deepai.org/api/toxicity-classification"
 
 TOXICITY_THRESHOLD = 0.85
 NSFW_THRESHOLD = 0.85
@@ -36,18 +35,17 @@ SAFE_COMMANDS = [
 
 
 async def check_text(text: str, bot=None) -> dict | None:
-    """Send text to external moderation API and return parsed JSON.
-    Fall back to direct Perspective API calls if the request fails.
-    """
+    """Analyze text using DeepAI's Toxicity Classification API."""
     try:
         resp = await asyncio.to_thread(
             requests.post,
             MOD_API_URL,
-            json={"text": text},
+            headers={"api-key": "4d428d58-a5d2-452b-8439-d4e4dd7372f5"},
+            data={"text": text},
             timeout=10,
         )
         resp.raise_for_status()
-        data = resp.json()
+        data = resp.json().get("output", {})
         logger.debug("Moderation API response: %s", data)
         return data
     except Exception as exc:
@@ -62,15 +60,7 @@ async def check_text(text: str, bot=None) -> dict | None:
             except Exception:
                 logger.debug("Could not notify log channel about API failure")
 
-        tox_score = await check_toxicity(text, bot)
-        if tox_score == 0.0:
-            return None
-        flagged = tox_score >= TOXICITY_THRESHOLD
-        return {
-            "flagged": flagged,
-            "score": tox_score,
-            "flags": {"toxicity": flagged},
-        }
+        return None
 
 async def process_violation(application: Application, message, user_id: int, score: float, reason: str):
     logger.warning("🔴 Violation Detected | Reason: %s | Score: %.2f | User: %d", reason, score, user_id)
@@ -135,13 +125,15 @@ def register(app: Application):
                     return
             result = await check_text(text, context.bot)
             if result:
-                flagged = result.get("flagged", False)
-                if flagged:
-                    cats = result.get("flags") or result.get("categories") or {}
-                    reason_list = [k for k, v in cats.items() if v]
-                    reason = ", ".join(reason_list) if reason_list else "violation"
-                    score = float(result.get("score", 1.0))
-                    await process_violation(context.application, message, user_id, score, reason)
+                score = float(result.get("toxicity", 0))
+                if score >= TOXICITY_THRESHOLD:
+                    await process_violation(
+                        context.application,
+                        message,
+                        user_id,
+                        score,
+                        "toxicity",
+                    )
                     return
 
         media = None


### PR DESCRIPTION
## Summary
- use DeepAI toxicity endpoint directly for text checks
- drop Perspective API fallback
- adapt moderation logic to new API output

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686ff7a005e48329ad87d48c3104aaf4