### PR TITLE
Add reusable banned word filter module

### DIFF
--- a/text_filter.py
+++ b/text_filter.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from typing import Set
+
+
+def load_banned_words(path: str = "banned_words.txt") -> Set[str]:
+    """Load banned words from a text file.
+
+    Parameters
+    ----------
+    path: str, optional
+        Path to the banned words file. By default ``banned_words.txt`` in the
+        same directory as this module.
+
+    Returns
+    -------
+    Set[str]
+        A set containing the banned words in lowercase. If the file is not
+        found, an empty set is returned.
+    """
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path(__file__).with_name(path)
+
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            return {line.strip().lower() for line in f if line.strip()}
+    except FileNotFoundError:
+        return set()
+
+
+def contains_banned_word(text: str, banned_words: Set[str]) -> bool:
+    """Check if the given text contains any banned word.
+
+    Matching is case-insensitive and substring-based.
+
+    Parameters
+    ----------
+    text: str
+        The text to scan.
+    banned_words: Set[str]
+        A set of banned words, typically produced by :func:`load_banned_words`.
+
+    Returns
+    -------
+    bool
+        ``True`` if any banned word is present in ``text``.
+    """
+    lower_text = text.lower()
+    return any(word in lower_text for word in banned_words)


### PR DESCRIPTION
## Summary
- add `text_filter.py` module for profanity filtering

## Testing
- `python - <<'PY'
import text_filter
print(text_filter.load_banned_words())
print(text_filter.contains_banned_word('this is a badWord example', {'badword'}))
PY`
- `python -m py_compile text_filter.py`


------
https://chatgpt.com/codex/tasks/task_b_687093eb0c888329859c56e0ce3d316e