### PR TITLE
Improve messaging and developer panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ OWNER_ID=1888832817
 LOG_CHANNEL_ID=-1001234567890
 DB_FILE=bot.db
 PANEL_IMAGE=https://files.catbox.moe/1v1bn8.jpg
+DEV_URL=https://t.me/Oxeign
+DEV_NAME=Oxeign

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ sudo systemctl start pingbot
 ### Render.com
 Create a new **Background Worker** pointing to this repository. Render uses `render.yaml` for configuration. Render defaults to the latest Python version which may be incompatible with pinned dependencies. This project targets **Python 3.11**, so the repository includes a `runtime.txt` and `.python-version` file to explicitly set the Python version during deployment.
 `render.yaml` installs packages using the `--only-binary=:all:` flag to ensure pre-built wheels.
+
+### MongoDB Setup
+This project uses SQLite by default for simplicity. If you prefer MongoDB,
+install `motor` and set `DATABASE_URL` to your Mongo connection string.
+Update the `database` module to use `motor.motor_asyncio.AsyncIOMotorClient`
+in place of `aiosqlite`.
 ### Example `.env`
 ```bash
 BOT_TOKEN=your_bot_token
@@ -48,6 +54,8 @@ OWNER_ID=1888832817
 LOG_CHANNEL_ID=-1001234567890
 DB_FILE=bot.db
 PANEL_IMAGE=https://example.com/panel.png
+DEV_URL=https://t.me/Oxeign
+DEV_NAME=Oxeign
 ```
 ### Environment Variables
 Edit `.env` with the following keys:
@@ -58,6 +66,8 @@ Edit `.env` with the following keys:
 - `LOG_CHANNEL_ID` – channel/group ID for logs
 - `DB_FILE` – path to the SQLite DB file. By default the value of `DATABASE_URL` is used unless it looks like a Postgres connection string. This avoids issues with hosts like Render that automatically define `DATABASE_URL` for Postgres.
 - `PANEL_IMAGE` – optional URL or file path to an image shown with the control panel.
+- `DEV_URL` – link shown in the Developer button
+- `DEV_NAME` – name used in the Developer alert
 - `DEBUG_UPDATES` – set to `1` to enable verbose logging of every incoming update. Useful when troubleshooting why the bot is not receiving commands.
 - `banned_words.txt` – list of words or phrases to filter, one per line.
 

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ class Config:
 
     PANEL_IMAGE = os.getenv("PANEL_IMAGE")
     DEV_URL = os.getenv("DEV_URL", "https://t.me/Oxeign")
+    DEV_NAME = os.getenv("DEV_NAME", "Oxeign")
 
     # Prefer DB_FILE to avoid clashing with hosting providers that predefine
     # DATABASE_URL for Postgres connections (e.g. Render.com). Fallback to

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -21,6 +21,10 @@ from config import Config
 def register(app: Application):
     async def broadcast_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if update.effective_user.id != Config.OWNER_ID:
+            await update.message.reply_text(
+                "❌ You are not authorized to broadcast messages.",
+                quote=True,
+            )
             return
         if not context.args:
             await update.message.reply_text("⚠️ Usage:\n`/broadcast <message>`", quote=True)
@@ -43,6 +47,10 @@ def register(app: Application):
     async def approve_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         message = update.effective_message
         if not await is_admin(message):
+            await message.reply_text(
+                "❌ You must be an admin to use this command.",
+                quote=True,
+            )
             return
         if not message.reply_to_message:
             await message.reply_text("👤 Please reply to a user to approve them.")
@@ -56,6 +64,10 @@ def register(app: Application):
     async def unapprove_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         message = update.effective_message
         if not await is_admin(message):
+            await message.reply_text(
+                "❌ You must be an admin to use this command.",
+                quote=True,
+            )
             return
         if not message.reply_to_message:
             await message.reply_text("👤 Please reply to a user to unapprove them.")
@@ -69,6 +81,10 @@ def register(app: Application):
     async def approved_list(update: Update, context: ContextTypes.DEFAULT_TYPE):
         message = update.effective_message
         if not await is_admin(message):
+            await message.reply_text(
+                "❌ You must be an admin to use this command.",
+                quote=True,
+            )
             return
 
         async with app.db.execute("SELECT id FROM users WHERE approved=1") as cur:
@@ -85,6 +101,10 @@ def register(app: Application):
     async def rmwarn_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         message = update.effective_message
         if not await is_admin(message):
+            await message.reply_text(
+                "❌ You must be an admin to use this command.",
+                quote=True,
+            )
             return
         if not message.reply_to_message:
             await message.reply_text("👤 Please reply to the user whose warnings you want to clear.")

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -33,7 +33,7 @@ def register(app: Application):
                 [InlineKeyboardButton("🛠️ Configure Group", callback_data="settings")],
                 [InlineKeyboardButton("📢 Broadcast", callback_data="bc")],
                 [InlineKeyboardButton("📘 Help", callback_data="help")],
-                [InlineKeyboardButton("👨‍💻 Developer", url=app.config.DEV_URL)],
+                [InlineKeyboardButton("👨‍💻 Developer", callback_data="dev")],
             ]
         )
 
@@ -155,6 +155,14 @@ def register(app: Application):
         )
 
     @catch_errors
+    async def cb_dev(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        query = update.callback_query
+        await query.answer(
+            text=f"👨‍💻 Developer: {app.config.DEV_NAME}\nContact: {app.config.DEV_URL}",
+            show_alert=True,
+        )
+
+    @catch_errors
     async def cb_back_home(update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query
         await query.answer()
@@ -219,6 +227,7 @@ def register(app: Application):
     app.add_handler(CallbackQueryHandler(cb_help, pattern="^help$"))
     app.add_handler(CallbackQueryHandler(cb_settings, pattern="^settings$"))
     app.add_handler(CallbackQueryHandler(cb_broadcast, pattern="^bc$"))
+    app.add_handler(CallbackQueryHandler(cb_dev, pattern="^dev$"))
     app.add_handler(CallbackQueryHandler(cb_back_home, pattern="^back_home$"))
     app.add_handler(ChatMemberHandler(track_my_member, ChatMemberHandler.MY_CHAT_MEMBER))
     app.add_handler(MessageHandler(filters.ChatType.PRIVATE & filters.COMMAND, unknown), group=999)


### PR DESCRIPTION
## Summary
- add developer name and URL config with example in `.env`
- show unauthorized messages in admin commands
- convert developer button to callback alert
- document environment variables and Mongo instructions in README

## Testing
- `pip install -q --no-deps python-telegram-bot==20.8 pyrogram==2.0.106 aiosqlite==0.19.0 python-dotenv==1.0.0 pillow==9.5.0 googletrans==4.0.0-rc1`
- `pip install -q httpx==0.26.0 --no-deps`
- `pip install -q PySocks tgcrypto pyaes --no-deps`
- `set -a && source .env.example && set +a && python predeploy.py`

------
https://chatgpt.com/codex/tasks/task_b_6873e4718cf88329b48157ba1586d188