### PR TITLE
Fix Motor/PyMongo import crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyrogram==2.0.106
 tgcrypto
-motor==3.3.1
+motor==3.7.1
 python-dotenv==1.0.0
 pillow==9.5.0  # Avoid 10.x for now
 googletrans==4.0.0-rc1


### PR DESCRIPTION
## Summary
- update Motor dependency to support latest PyMongo

## Testing
- `pip install -r requirements.txt`
- `python predeploy.py` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_b_687526fc0c00832991ac65eb5c61d286