### PR TITLE
Fix start command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python -m run
+web: python run.py

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Modern moderation bot built with **Pyrogram** and **MongoDB**.
 1. Install **Python 3.11** and create a virtual environment (optional).
 2. Copy `.env.example` to `.env` and fill the values.
 3. Install requirements with `pip install -r requirements.txt`.
-4. Run with `python -m run`.
+4. Run with `python run.py`.
 
 ### VPS (systemd)
 Place `pingbot.service` in `/etc/systemd/system/`, adjust paths, then:

--- a/render.yaml
+++ b/render.yaml
@@ -4,4 +4,4 @@ services:
     env: python
     plan: free
     buildCommand: pip install --no-cache-dir --only-binary=:all: -r requirements.txt
-    startCommand: python -m run
+    startCommand: python run.py


### PR DESCRIPTION
## Summary
- update start command to use `python run.py`

## Testing
- `python run.py` *(fails: No module named 'pyrogram')*

------
https://chatgpt.com/codex/tasks/task_b_68752888d2488329b1e7c8d5ea889702