### PR TITLE
Fix callback routing and group filters

### DIFF
--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -7,7 +7,9 @@ from config import Config
 def register(app: Client):
     db = get_db()
 
-    @app.on_message(filters.command("broadcast") & filters.user(Config.OWNER_ID))
+    @app.on_message(
+        filters.command("broadcast") & filters.group & filters.user(Config.OWNER_ID)
+    )
     async def broadcast(client: Client, message: Message):
         if len(message.command) < 2:
             await message.reply_text(
@@ -28,7 +30,9 @@ def register(app: Client):
             quote=True,
         )
 
-    @app.on_message(filters.command("broadcast") & ~filters.user(Config.OWNER_ID))
+    @app.on_message(
+        filters.command("broadcast") & filters.group & ~filters.user(Config.OWNER_ID)
+    )
     async def no_broadcast(_: Client, message: Message):
         await message.reply_text(
             "❌ Only the bot owner can broadcast messages.",

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,5 +1,10 @@
 from pyrogram import Client, filters
-from pyrogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
+from pyrogram.types import (
+    Message,
+    CallbackQuery,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+)
 from helpers.panels import main_panel
 from config import Config
 
@@ -27,6 +32,7 @@ def register(app: Client):
     async def panel_callbacks(_, query: CallbackQuery):
         data = query.data
         if data == "text_timer":
+            await query.answer()
             await query.message.edit_text(
                 "🗑 **Text Timer Setup**\n"
                 "Set how long text messages stay before deletion.\n\n"
@@ -37,6 +43,7 @@ def register(app: Client):
                 parse_mode="markdown",
             )
         elif data == "media_timer":
+            await query.answer()
             await query.message.edit_text(
                 "📷 **Media Timer Setup**\n"
                 "Control when photos and other media are removed.\n\n"
@@ -47,6 +54,7 @@ def register(app: Client):
                 parse_mode="markdown",
             )
         elif data == "broadcast_panel":
+            await query.answer()
             await query.message.edit_text(
                 "📢 **Broadcast Messages**\n"
                 "Send a message to all added chats.\n\n"
@@ -57,6 +65,7 @@ def register(app: Client):
                 parse_mode="markdown",
             )
         elif data == "abuse_panel":
+            await query.answer()
             await query.message.edit_text(
                 "🛡 **Abuse Filter**\n"
                 "Manage abusive words that trigger deletion.\n\n"
@@ -68,6 +77,7 @@ def register(app: Client):
                 parse_mode="markdown",
             )
         elif data == "main_panel":
+            await query.answer()
             await query.message.edit_text(
                 "**Control Panel**",
                 reply_markup=main_panel(),


### PR DESCRIPTION
## Summary
- add `query.answer()` in panel callbacks so buttons respond
- limit `/broadcast` command to groups and hook unauthorized usage

## Testing
- `python predeploy.py` *(fails: Database not initialized)*

------
https://chatgpt.com/codex/tasks/task_b_687536965e4483298e22ffb7a5ecbd7a