### PR TITLE
Fix callback routing and admin commands

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -8,7 +8,9 @@ from helpers.abuse import add_word, remove_word
 def register(app: Client):
     db = get_db()
 
-    @app.on_message(filters.command("set_text_timer") & filters.group)
+    @app.on_message(
+        filters.command("set_text_timer") & (filters.group | filters.private)
+    )
     @require_admin
     async def set_text(client: Client, message: Message):
         if len(message.command) < 2 or not message.command[1].isdigit():
@@ -28,7 +30,9 @@ def register(app: Client):
             quote=True,
         )
 
-    @app.on_message(filters.command("set_media_timer") & filters.group)
+    @app.on_message(
+        filters.command("set_media_timer") & (filters.group | filters.private)
+    )
     @require_admin
     async def set_media(client: Client, message: Message):
         if len(message.command) < 2 or not message.command[1].isdigit():
@@ -48,7 +52,7 @@ def register(app: Client):
             quote=True,
         )
 
-    @app.on_message(filters.command("addabuse") & filters.group)
+    @app.on_message(filters.command("addabuse") & (filters.group | filters.private))
     @require_admin
     async def add_abuse(client: Client, message: Message):
         if len(message.command) < 2:
@@ -60,7 +64,7 @@ def register(app: Client):
         await add_word(message.command[1])
         await message.reply_text("✅ Word added.", quote=True)
 
-    @app.on_message(filters.command("removeabuse") & filters.group)
+    @app.on_message(filters.command("removeabuse") & (filters.group | filters.private))
     @require_admin
     async def remove_abuse(client: Client, message: Message):
         if len(message.command) < 2:

--- a/handlers/broadcast.py
+++ b/handlers/broadcast.py
@@ -8,7 +8,9 @@ def register(app: Client):
     db = get_db()
 
     @app.on_message(
-        filters.command("broadcast") & filters.group & filters.user(Config.OWNER_ID)
+        filters.command("broadcast")
+        & (filters.group | filters.private)
+        & filters.user(Config.OWNER_ID)
     )
     async def broadcast(client: Client, message: Message):
         if len(message.command) < 2:
@@ -31,7 +33,9 @@ def register(app: Client):
         )
 
     @app.on_message(
-        filters.command("broadcast") & filters.group & ~filters.user(Config.OWNER_ID)
+        filters.command("broadcast")
+        & (filters.group | filters.private)
+        & ~filters.user(Config.OWNER_ID)
     )
     async def no_broadcast(_: Client, message: Message):
         await message.reply_text(

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -31,40 +31,40 @@ def register(app: Client):
     @app.on_callback_query()
     async def panel_callbacks(_, query: CallbackQuery):
         data = query.data
-        if data == "text_timer":
+        if data == "panel:text_timer":
             await query.answer()
             await query.message.edit_text(
                 "🗑 **Text Timer Setup**\n"
                 "Set how long text messages stay before deletion.\n\n"
                 "Usage:\n`/set_text_timer <seconds>`",
                 reply_markup=InlineKeyboardMarkup(
-                    [[InlineKeyboardButton("◀️ Back", callback_data="main_panel")]]
+                    [[InlineKeyboardButton("◀️ Back", callback_data="panel:main")]]
                 ),
                 parse_mode="markdown",
             )
-        elif data == "media_timer":
+        elif data == "panel:media_timer":
             await query.answer()
             await query.message.edit_text(
                 "📷 **Media Timer Setup**\n"
                 "Control when photos and other media are removed.\n\n"
                 "Usage:\n`/set_media_timer <seconds>`",
                 reply_markup=InlineKeyboardMarkup(
-                    [[InlineKeyboardButton("◀️ Back", callback_data="main_panel")]]
+                    [[InlineKeyboardButton("◀️ Back", callback_data="panel:main")]]
                 ),
                 parse_mode="markdown",
             )
-        elif data == "broadcast_panel":
+        elif data == "panel:broadcast":
             await query.answer()
             await query.message.edit_text(
                 "📢 **Broadcast Messages**\n"
                 "Send a message to all added chats.\n\n"
                 "Usage:\n`/broadcast <message>`",
                 reply_markup=InlineKeyboardMarkup(
-                    [[InlineKeyboardButton("◀️ Back", callback_data="main_panel")]]
+                    [[InlineKeyboardButton("◀️ Back", callback_data="panel:main")]]
                 ),
                 parse_mode="markdown",
             )
-        elif data == "abuse_panel":
+        elif data == "panel:abuse_filter":
             await query.answer()
             await query.message.edit_text(
                 "🛡 **Abuse Filter**\n"
@@ -72,11 +72,11 @@ def register(app: Client):
                 "Add word: `/addabuse <word>`\n"
                 "Remove word: `/removeabuse <word>`",
                 reply_markup=InlineKeyboardMarkup(
-                    [[InlineKeyboardButton("◀️ Back", callback_data="main_panel")]]
+                    [[InlineKeyboardButton("◀️ Back", callback_data="panel:main")]]
                 ),
                 parse_mode="markdown",
             )
-        elif data == "main_panel":
+        elif data == "panel:main":
             await query.answer()
             await query.message.edit_text(
                 "**Control Panel**",
@@ -84,4 +84,4 @@ def register(app: Client):
                 parse_mode="markdown",
             )
         else:
-            await query.answer()
+            await query.answer("Unknown option", show_alert=False)

--- a/helpers/panels.py
+++ b/helpers/panels.py
@@ -1,22 +1,37 @@
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 
+PANEL_PREFIX = "panel:"
+
+
 def main_panel() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("🗑 Text Timer", callback_data="text_timer")],
-            [InlineKeyboardButton("📷 Media Timer", callback_data="media_timer")],
-            [InlineKeyboardButton("📢 Broadcast", callback_data="broadcast_panel")],
-            [InlineKeyboardButton("🛡 Abuse Filter", callback_data="abuse_panel")],
+            [
+                InlineKeyboardButton(
+                    "🗑 Text Timer", callback_data=f"{PANEL_PREFIX}text_timer"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "📷 Media Timer", callback_data=f"{PANEL_PREFIX}media_timer"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "📢 Broadcast", callback_data=f"{PANEL_PREFIX}broadcast"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "🛡 Abuse Filter", callback_data=f"{PANEL_PREFIX}abuse_filter"
+                )
+            ],
             [
                 InlineKeyboardButton(
                     "🧑‍💻 Developer Info", url="https://t.me/samratyash32169"
                 )
             ],
-            [
-                InlineKeyboardButton(
-                    "💬 Support", url="https://t.me/+Sn1PMhrr_nIwM2Y1"
-                )
-            ],
+            [InlineKeyboardButton("💬 Support", url="https://t.me/+Sn1PMhrr_nIwM2Y1")],
         ]
     )

--- a/run.py
+++ b/run.py
@@ -22,6 +22,7 @@ async def main():
     )
     app.db = db
     register_all(app)
+    logger.info("[READY] Command handlers active")
     await app.start()
     logger.info("[READY] Bot is now live ✅")
     await idle()


### PR DESCRIPTION
## Summary
- ensure inline panel buttons use unique callback data
- handle all callbacks from a single router
- allow admin commands in private chats
- enable broadcasting from PM for owner
- log when command handlers are ready

## Testing
- `python -m py_compile helpers/panels.py handlers/start.py handlers/admin.py handlers/broadcast.py run.py`

------
https://chatgpt.com/codex/tasks/task_b_68753985140c83299de83ef18148fae9