### PR TITLE
Fix inline handlers and safe formatting

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -21,7 +21,9 @@ def register(app: Client):
         else:
             await send_message_safe(message, "**Control Panel**", reply_markup=main_panel())
 
-    @app.on_message(filters.command(["start", "menu", "help"]))
+    @app.on_message(
+        filters.command(["start", "menu", "help"]) & (filters.group | filters.private)
+    )
     async def start(_, message: Message):
         await send_panel(message)
 
@@ -59,6 +61,6 @@ def register(app: Client):
 
         await query.answer()
 
-    @app.on_message(filters.command("ping"))
+    @app.on_message(filters.command("ping") & (filters.group | filters.private))
     async def ping(_, message: Message):
         await message.reply_text("pong")

--- a/helpers/formatting.py
+++ b/helpers/formatting.py
@@ -14,18 +14,24 @@ def escape_markdown(text: str) -> str:
     return MD_V2_SPECIAL.sub(r"\\\1", text)
 
 async def safe_edit(message: Message, text: str, **kwargs) -> None:
-    """Edit a message using MarkdownV2 and fall back to HTML on failure."""
+    """Edit a message trying MarkdownV2, then HTML, then plain text."""
     try:
         await message.edit_text(
             escape_markdown(text), parse_mode="MarkdownV2", **kwargs
         )
+        return
     except Exception as e:
-        logger.warning("❗ Failed to edit message %s: %s", message.id, e)
+        logger.warning("Markdown edit failed: %s", e)
+    try:
         await message.edit_text(text, parse_mode="HTML", **kwargs)
+        return
+    except Exception as e:
+        logger.warning("HTML edit failed: %s", e)
+    await message.edit_text(text, **kwargs)
 
 
 async def send_message_safe(target: Message | Client, text: str, **kwargs) -> Message:
-    """Reply or send a message safely using MarkdownV2, fall back to HTML."""
+    """Reply or send a message using MarkdownV2 -> HTML -> plain text."""
     reply_func = getattr(target, "reply", None)
     send_func = getattr(target, "send_message", None)
 
@@ -35,8 +41,14 @@ async def send_message_safe(target: Message | Client, text: str, **kwargs) -> Me
             return await reply_func(formatted, parse_mode="MarkdownV2", **kwargs)
         return await send_func(formatted, parse_mode="MarkdownV2", **kwargs)
     except Exception as e:
-        logger.debug("Markdown failed: %s", e)
+        logger.debug("Markdown send failed: %s", e)
+    try:
         if reply_func:
             return await reply_func(text, parse_mode="HTML", **kwargs)
         return await send_func(text, parse_mode="HTML", **kwargs)
+    except Exception as e:
+        logger.debug("HTML send failed: %s", e)
+    if reply_func:
+        return await reply_func(text, **kwargs)
+    return await send_func(text, **kwargs)
 


### PR DESCRIPTION
## Summary
- allow `/start`, `/menu`, `/help` and `ping` in groups and PMs
- fallback to HTML and plain text when editing/sending messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687552169af88329af541f6deb956bb2