### PR TITLE
Finalize broadcast & abuse filter

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -7,13 +7,15 @@ logger = logging.getLogger(__name__)
 
 def register_all(app: Client):
     """Import and register all Pyrogram handlers."""
-    from . import start, admin, autodelete, broadcast
+    from . import start, admin, autodelete, broadcast, moderation
 
     start.register(app)
-    logger.info("[REGISTERED] start.py")
+    logger.info("[REGISTERED] start.py ✅")
     admin.register(app)
-    logger.info("[REGISTERED] admin.py")
+    logger.info("[REGISTERED] admin.py ✅")
     autodelete.register(app)
-    logger.info("[REGISTERED] autodelete.py")
+    logger.info("[REGISTERED] autodelete.py ✅")
     broadcast.register(app)
-    logger.info("[REGISTERED] broadcast.py")
+    logger.info("[REGISTERED] broadcast.py ✅")
+    moderation.register(app)
+    logger.info("[REGISTERED] moderation.py ✅")

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -3,6 +3,7 @@ from pyrogram.types import Message
 from helpers.decorators import require_admin
 from helpers.mongo import get_db
 from helpers.abuse import add_word, remove_word
+from config import Config
 
 
 def register(app: Client):
@@ -52,8 +53,11 @@ def register(app: Client):
             quote=True,
         )
 
-    @app.on_message(filters.command("addabuse") & (filters.group | filters.private))
-    @require_admin
+    @app.on_message(
+        filters.command("addabuse")
+        & (filters.group | filters.private)
+        & filters.user(Config.OWNER_ID)
+    )
     async def add_abuse(client: Client, message: Message):
         if len(message.command) < 2:
             await message.reply_text(
@@ -64,8 +68,11 @@ def register(app: Client):
         await add_word(message.command[1])
         await message.reply_text("✅ Word added.", quote=True)
 
-    @app.on_message(filters.command("removeabuse") & (filters.group | filters.private))
-    @require_admin
+    @app.on_message(
+        filters.command("removeabuse")
+        & (filters.group | filters.private)
+        & filters.user(Config.OWNER_ID)
+    )
     async def remove_abuse(client: Client, message: Message):
         if len(message.command) < 2:
             await message.reply_text(

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,7 +3,7 @@
 from .mongo import connect, get_db
 from .perms import is_admin
 from .decorators import require_admin, catch_errors
-from .abuse import add_word, remove_word, contains_abuse, get_words
+from .abuse import add_word, remove_word, contains_abuse, init_words
 from .formatting import send_message_safe, safe_edit
 
 __all__ = [
@@ -15,7 +15,7 @@ __all__ = [
     "add_word",
     "remove_word",
     "contains_abuse",
-    "get_words",
+    "init_words",
     "send_message_safe",
     "safe_edit",
 ]


### PR DESCRIPTION
## Summary
- store banned words in-memory via helpers.abuse
- restrict `/addabuse` and `/removeabuse` to bot owner
- broadcast messages to all groups with per-chat logging
- register all handler modules and log successful loading
- translate group messages for abuse scanning
- auto register groups for broadcasting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687555a291948329a4fd54b3ae9029ab