### PR TITLE
Add per-group abuse whitelist system

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -55,7 +55,23 @@ def register(app: Client):
         elif data == "panel:abuse_filter":
             await safe_edit(
                 query.message,
-                "🛡 *Abuse Filter System*\nDelete abusive messages automatically.\n\nCommands:\n• `/addabuse <word>` — Block word\n• `/removeabuse <word>` — Unblock word",
+                "🛡 *Abuse Filter System*\n"
+                "Delete abusive messages automatically across languages. "
+                "Messages containing words from `banned_words.txt` are removed "
+                "and the sender is warned. Group owners can whitelist words.\n\n"
+                "Commands:\n"
+                "• `/addabuse <word>` — Block word globally\n"
+                "• `/removeabuse <word>` — Unblock word globally",
+                reply_markup=main_panel(),
+            )
+
+        elif data == "panel:whitelist_word":
+            await safe_edit(
+                query.message,
+                "⚪ *Whitelist System*\n\n"
+                "• `/whitelist <word>` – Allow a banned word in this group\n"
+                "• `/removewhitelist <word>` – Re-block that word\n"
+                "🔒 Only group *owner* can use these commands.",
                 reply_markup=main_panel(),
             )
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,8 +1,8 @@
 """Utility helpers for the moderation bot."""
 
 from .mongo import connect, get_db
-from .perms import is_admin
-from .decorators import require_admin, catch_errors
+from .perms import is_admin, is_owner
+from .decorators import require_admin, require_owner, catch_errors
 from .abuse import add_word, remove_word, contains_abuse, init_words
 from .formatting import send_message_safe, safe_edit
 
@@ -10,7 +10,9 @@ __all__ = [
     "connect",
     "get_db",
     "is_admin",
+    "is_owner",
     "require_admin",
+    "require_owner",
     "catch_errors",
     "add_word",
     "remove_word",

--- a/helpers/abuse.py
+++ b/helpers/abuse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Set
+from typing import Set, Iterable
 
 BANNED_WORDS: Set[str] = set()
 _WORDS_FILE: Path | None = None
@@ -54,6 +54,12 @@ def remove_word(word: str) -> None:
         _write_words()
 
 
-def contains_abuse(text: str) -> bool:
+def contains_abuse(text: str, whitelist: Iterable[str] | None = None) -> bool:
+    """Return ``True`` if ``text`` contains a banned word not in ``whitelist``."""
     tokens = re.findall(r"\w+", text.lower())
-    return any(token in BANNED_WORDS for token in tokens)
+    if whitelist:
+        ignored = {w.lower() for w in whitelist}
+    else:
+        ignored = set()
+    banned = BANNED_WORDS - ignored
+    return any(token in banned for token in tokens)

--- a/helpers/decorators.py
+++ b/helpers/decorators.py
@@ -26,6 +26,27 @@ def require_admin(func):
     return wrapper
 
 
+def require_owner(func):
+    @functools.wraps(func)
+    async def wrapper(client, message: Message, *args, **kwargs):
+        from .perms import is_owner
+        from config import Config
+
+        if message.from_user and message.from_user.id == Config.OWNER_ID:
+            return await func(client, message, *args, **kwargs)
+
+        if not await is_owner(client, message):
+            await message.reply_text(
+                "❌ Only the group owner can use this command.",
+                quote=True,
+            )
+            return
+
+        return await func(client, message, *args, **kwargs)
+
+    return wrapper
+
+
 def catch_errors(func):
     @functools.wraps(func)
     async def wrapper(client, message, *args, **kwargs):

--- a/helpers/panels.py
+++ b/helpers/panels.py
@@ -27,6 +27,11 @@ def main_panel() -> InlineKeyboardMarkup:
                     "🛡 Abuse Filter", callback_data=f"{PANEL_PREFIX}abuse_filter"
                 )
             ],
+            [
+                InlineKeyboardButton(
+                    "⚪ Whitelist Word", callback_data=f"{PANEL_PREFIX}whitelist_word"
+                )
+            ],
             [InlineKeyboardButton("👨‍💻 Developer Info", url="https://t.me/samratyash32169")],
             [InlineKeyboardButton("💬 Support", url="https://t.me/+Sn1PMhrr_nIwM2Y1")],
         ]

--- a/helpers/perms.py
+++ b/helpers/perms.py
@@ -1,8 +1,17 @@
-from pyrogram import Client, filters
+from pyrogram import Client
 from pyrogram.types import Message
+from pyrogram.enums import ChatMemberStatus
 
 async def is_admin(client: Client, message: Message) -> bool:
     if not message.chat or not message.from_user:
         return False
     member = await client.get_chat_member(message.chat.id, message.from_user.id)
-    return member.status in ("administrator", "creator")
+    return member.status in (ChatMemberStatus.ADMINISTRATOR, ChatMemberStatus.OWNER)
+
+
+async def is_owner(client: Client, message: Message) -> bool:
+    """Return ``True`` if the user is the chat owner."""
+    if not message.chat or not message.from_user:
+        return False
+    member = await client.get_chat_member(message.chat.id, message.from_user.id)
+    return member.status == ChatMemberStatus.OWNER


### PR DESCRIPTION
## Summary
- implement is_owner and require_owner helpers
- add group-specific whitelist commands
- extend abuse filter with per-group whitelist and admin warnings
- update control panel UI and callback text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68755c47973c8329866082fa4f4037ce