### PR TITLE
Track groups for broadcasts

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 def register_all(app: Client):
     """Import and register all Pyrogram handlers."""
-    from . import start, admin, autodelete, broadcast, moderation
+    from . import start, admin, autodelete, broadcast, groups, moderation
 
     start.register(app)
     logger.info("[REGISTERED] start.py ✅")
@@ -17,5 +17,7 @@ def register_all(app: Client):
     logger.info("[REGISTERED] autodelete.py ✅")
     broadcast.register(app)
     logger.info("[REGISTERED] broadcast.py ✅")
+    groups.register(app)
+    logger.info("[REGISTERED] groups.py ✅")
     moderation.register(app)
     logger.info("[REGISTERED] moderation.py ✅")

--- a/handlers/groups.py
+++ b/handlers/groups.py
@@ -1,0 +1,44 @@
+import logging
+from pyrogram import Client, filters
+from pyrogram.types import Message
+from config import Config
+from helpers.mongo import get_db
+from helpers.decorators import catch_errors
+
+logger = logging.getLogger(__name__)
+
+
+def register(app: Client):
+    db = get_db()
+
+    @app.on_message(filters.new_chat_members & filters.group)
+    @catch_errors
+    async def track_bot_added(client: Client, message: Message):
+        me = await client.get_me()
+        if any(m.id == me.id for m in message.new_chat_members):
+            await db.group_settings.update_one(
+                {"chat_id": message.chat.id},
+                {"$setOnInsert": {"chat_id": message.chat.id}},
+                upsert=True,
+            )
+            logger.info("[GENERAL] Bot added to group %s", message.chat.id)
+            if Config.LOG_CHANNEL:
+                try:
+                    text = f"➕ Bot added to group {message.chat.id}"
+                    await client.send_message(Config.LOG_CHANNEL, text)
+                except Exception as exc:
+                    logger.warning("Failed to send log: %s", exc)
+
+    @app.on_message(filters.left_chat_member & filters.group)
+    @catch_errors
+    async def track_bot_left(client: Client, message: Message):
+        me = await client.get_me()
+        if message.left_chat_member and message.left_chat_member.id == me.id:
+            await db.group_settings.delete_one({"chat_id": message.chat.id})
+            logger.info("[GENERAL] Bot removed from group %s", message.chat.id)
+            if Config.LOG_CHANNEL:
+                try:
+                    text = f"➖ Bot removed from group {message.chat.id}"
+                    await client.send_message(Config.LOG_CHANNEL, text)
+                except Exception as exc:
+                    logger.warning("Failed to send log: %s", exc)


### PR DESCRIPTION
## Summary
- register a new module `groups.py`
- add handlers for when the bot joins or leaves a group
- ensure new handlers are registered

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687662629de4832985f1c5ddeb4157b0