### PR TITLE
Add reloadwords command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Modern moderation bot built with **Pyrogram** and **MongoDB**.
 - `/ping` – check bot status
 - `/approve` `/unapprove` `/approved` `/rmwarn` – admin tools
 - `/broadcast <text>` – owner broadcast
+- `/reloadwords` – reload the banned words list
 
 ## Usage
 1. Start the bot in a private chat or add it to a group.

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -2,7 +2,7 @@ from pyrogram import Client, filters
 from pyrogram.types import Message
 from helpers.decorators import require_admin, require_owner
 from helpers.mongo import get_db
-from helpers.abuse import add_word, remove_word
+from helpers.abuse import add_word, remove_word, init_words
 from config import Config
 
 
@@ -116,3 +116,12 @@ def register(app: Client):
             upsert=True,
         )
         await message.reply_text("✅ Word removed from whitelist.", quote=True)
+
+    @app.on_message(filters.command("reloadwords") & filters.group)
+    @require_admin
+    async def reload_banned_words(client: Client, message: Message):
+        try:
+            init_words()
+            await message.reply_text("✅ Banned words reloaded successfully.", quote=True)
+        except Exception as e:
+            await message.reply_text(f"❌ Failed to reload: {e}", quote=True)


### PR DESCRIPTION
## Summary
- allow reloading banned words list with `/reloadwords`
- document the new command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6876770cacc88329b2160f33b5cc4752