### PR TITLE
Improve config and moderation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ API_ID=12345
 API_HASH=your_api_hash
 OWNER_ID=1888832817
 LOG_CHANNEL_ID=-1001234567890
+MODLOG_CHANNEL_ID=
 MONGO_URI=mongodb://localhost:27017/modbot
 PANEL_IMAGE=https://files.catbox.moe/1v1bn8.jpg
 DEV_URL=https://t.me/Oxeign

--- a/config.py
+++ b/config.py
@@ -1,32 +1,52 @@
-import os
-from dotenv import load_dotenv
+from __future__ import annotations
 
-load_dotenv()
+from pydantic import Field, ValidationError, field_validator
+from pydantic_settings import BaseSettings
 
 
-class Config:
-    API_ID = int(os.getenv("API_ID", 0))
-    API_HASH = os.getenv("API_HASH", "")
-    BOT_TOKEN = os.getenv("BOT_TOKEN", "")
-    MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
-    OWNER_ID = int(os.getenv("OWNER_ID", 0))
-    LOG_CHANNEL = int(os.getenv("LOG_CHANNEL_ID", 0))
-    PANEL_IMAGE = os.getenv("PANEL_IMAGE", "")
-    DEV_URL = os.getenv("DEV_URL", "https://t.me/botsyard")
-    DEV_NAME = os.getenv("DEV_NAME", "Developer")
-    SUCCESS_EMOJI = os.getenv("SUCCESS_EMOJI", "✅")
-    ERROR_EMOJI = os.getenv("ERROR_EMOJI", "❌")
-    WARNING_EMOJI = os.getenv("WARNING_EMOJI", "⚠️")
-    SUDO_USERS = {int(x) for x in os.getenv("SUDO_USERS", str(OWNER_ID)).split() if x}
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
 
-    @classmethod
-    def validate(cls) -> None:
-        required = {
-            "API_ID": cls.API_ID,
-            "API_HASH": cls.API_HASH,
-            "BOT_TOKEN": cls.BOT_TOKEN,
-            "OWNER_ID": cls.OWNER_ID,
-        }
-        missing = [k for k, v in required.items() if not v]
-        if missing:
-            raise RuntimeError(f"Missing required config values: {', '.join(missing)}")
+    API_ID: int = Field(..., description="Telegram API ID")
+    API_HASH: str = Field(..., description="Telegram API hash")
+    BOT_TOKEN: str = Field(..., description="Bot token")
+    OWNER_ID: int = Field(..., description="Owner user ID")
+
+    LOG_CHANNEL: int = Field(0, alias="LOG_CHANNEL_ID")
+    MODLOG_CHANNEL: int = Field(0, alias="MODLOG_CHANNEL_ID")
+    MONGO_URI: str = Field("mongodb://localhost:27017", description="MongoDB URI")
+    PANEL_IMAGE: str = Field("", description="Optional panel image URL")
+    DEV_URL: str = Field("https://t.me/botsyard", description="Developer URL")
+    DEV_NAME: str = Field("Developer", description="Developer name")
+    SUCCESS_EMOJI: str = Field("✅")
+    ERROR_EMOJI: str = Field("❌")
+    WARNING_EMOJI: str = Field("⚠️")
+    SUDO_USERS: set[int] = Field(default_factory=set)
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+    @field_validator("SUDO_USERS", mode="before")
+    def _split_sudo(cls, v: str | set[int] | None) -> set[int]:
+        if not v:
+            return set()
+        if isinstance(v, set):
+            return v
+        return {int(x) for x in str(v).split() if x}
+
+    def model_post_init(self, __context) -> None:  # pragma: no cover - pydantic hook
+        if not self.SUDO_USERS:
+            self.SUDO_USERS = {self.OWNER_ID}
+
+
+try:  # pragma: no cover - executed at import time
+    Config = Settings()
+except ValidationError as exc:  # pragma: no cover - configuration must be valid
+    raise RuntimeError(f"Configuration error: {exc}") from exc
+
+
+def validate() -> None:
+    """Compatibility wrapper for legacy calls."""
+    # Instantiating ``Config`` already validates all fields
+    _ = Config

--- a/pingbot.service
+++ b/pingbot.service
@@ -6,7 +6,10 @@ After=network.target
 WorkingDirectory=/opt/pingbot
 ExecStart=/usr/bin/python3 run.py
 Restart=always
+RestartSec=5
 EnvironmentFile=/opt/pingbot/.env
+StandardOutput=append:/var/log/pingbot.log
+StandardError=append:/var/log/pingbot.log
 
 [Install]
 WantedBy=multi-user.target

--- a/render.yaml
+++ b/render.yaml
@@ -3,5 +3,7 @@ services:
     name: telegram-moderation-bot
     env: python
     plan: free
-    buildCommand: pip install --no-cache-dir --only-binary=:all: -r requirements.txt
+    buildCommand: |
+      python predeploy.py && \
+      pip install --no-cache-dir --only-binary=:all: -r requirements.txt
     startCommand: "python run.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ motor==3.7.1
 python-dotenv==1.0.0
 pillow==9.5.0  # Avoid 10.x for now
 googletrans==4.0.0-rc1
+pydantic>=2.0


### PR DESCRIPTION
## Summary
- load env vars via pydantic with validation
- add category based moderation with fuzzy matching
- support filter toggles for groups
- log moderation events
- predeploy checks validate env file
- restart service reliably and log to file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python predeploy.py` *(fails: Missing optional deps)*

------
https://chatgpt.com/codex/tasks/task_b_6877b17824588329bda3647d5b7a9126