### PR TITLE
Fix missing pydantic-settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.0.0
 pillow==9.5.0  # Avoid 10.x for now
 googletrans==4.0.0-rc1
 pydantic>=2.0
+pydantic-settings>=2.0


### PR DESCRIPTION
## Summary
- install pydantic-settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6877b6a8a1a0832997500adfb77215ee