### PR TITLE
Fix Config validation call

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from pyrogram import Client, idle
-from config import Config
+from config import Config, validate
 from helpers.mongo import connect
 from handlers import register_all
 
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 async def main():
-    Config.validate()
+    validate()
     logger.info("[INFO] Connecting to MongoDB...")
     db = await connect(Config.MONGO_URI)
     logger.info("[INFO] Initializing bot...")


### PR DESCRIPTION
## Summary
- call `validate` function correctly to load configuration

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_b_6877c2094940832988859190e9ead2bd