### PR TITLE
Fix logger initialization

### DIFF
--- a/handlers/moderation.py
+++ b/handlers/moderation.py
@@ -13,6 +13,8 @@ from helpers.mongo import get_db
 from helpers.abuse import load_words
 from config import Config
 
+logger = logging.getLogger(__name__)
+
 BANNED_WORDS = load_words()
 logger.info("Loaded %d banned words", len(BANNED_WORDS))
 
@@ -26,8 +28,6 @@ for cat, words in _CATEGORY_EXTRA.items():
     for w in words:
         WORD_CATEGORY[w] = cat
         BANNED_WORDS.add(w)
-
-logger = logging.getLogger(__name__)
 
 
 def translate_text(text: str) -> str:


### PR DESCRIPTION
## Summary
- fix `logger` initialization ordering in `handlers/moderation.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python run.py` *(fails: missing required env vars)*

------
https://chatgpt.com/codex/tasks/task_b_6877c59966a0832991eacf48ed82d65a