### PR TITLE
Fix missing handler import

### DIFF
--- a/handlers/groups.py
+++ b/handlers/groups.py
@@ -4,7 +4,11 @@ from pyrogram.types import Message
 from config import Config
 from helpers.mongo import get_db
 from helpers.decorators import catch_errors
-from .start import send_welcome
+# "send_welcome" lives in panels.py where the /start command is
+# implemented. The previous import from a non-existent "start" module
+# caused a ModuleNotFoundError during runtime. Import it from panels
+# instead so group join events can reuse the same welcome message.
+from .panels import send_welcome
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- correct the import path for `send_welcome`

## Testing
- `pip install -r requirements.txt`
- `pip install aiosqlite`
- `export API_ID=1 API_HASH=hash BOT_TOKEN=test OWNER_ID=1`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6877da75601883298e097370d396cbeb