### PR TITLE
Improve moderation bot stability and features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,9 @@ API_ID=12345
 API_HASH=your_api_hash
 OWNER_ID=1888832817
 LOG_CHANNEL_ID=-1001234567890
-MODLOG_CHANNEL_ID=
+MODLOG_CHANNEL_ID=-1009876543210
+DEV_URL=https://t.me/yourchannel
+# Optional settings
 MONGO_URI=mongodb://localhost:27017/modbot
 PANEL_IMAGE=https://files.catbox.moe/1v1bn8.jpg
-DEV_URL=https://t.me/Oxeign
 DEV_NAME=Oxeign

--- a/config.py
+++ b/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from pydantic import Field, ValidationError, field_validator
-from pydantic_settings import BaseSettings
+from pydantic import BaseSettings, Field, ValidationError, validator
 
 
 class Settings(BaseSettings):
@@ -27,7 +26,7 @@ class Settings(BaseSettings):
         env_file = ".env"
         case_sensitive = False
 
-    @field_validator("SUDO_USERS", mode="before")
+    @validator("SUDO_USERS", pre=True)
     def _split_sudo(cls, v: str | set[int] | None) -> set[int]:
         if not v:
             return set()

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -15,6 +15,9 @@ def register_all(app: Client):
         activity_log as logmod,
         moderation,
         panels,
+        status,
+        help as helpmod,
+        settings,
     )
 
     panels.register(app)
@@ -25,9 +28,15 @@ def register_all(app: Client):
     logger.info("[REGISTERED] autodelete.py ✅")
     broadcast.register(app)
     logger.info("[REGISTERED] broadcast.py ✅")
+    helpmod.register(app)
+    logger.info("[REGISTERED] help.py ✅")
     groups.register(app)
     logger.info("[REGISTERED] groups.py ✅")
     moderation.register(app)
     logger.info("[REGISTERED] moderation.py ✅")
+    status.register(app)
+    logger.info("[REGISTERED] status.py ✅")
+    settings.register(app)
+    logger.info("[REGISTERED] settings.py ✅")
     logmod.register(app)
     logger.info("[REGISTERED] activity_log.py ✅")

--- a/handlers/help.py
+++ b/handlers/help.py
@@ -1,0 +1,9 @@
+from helpers.compat import Client, Message, filters
+from helpers.formatting import send_message_safe
+from texts import HELP_TEXT
+
+
+def register(app: Client):
+    @app.on_message(filters.command("help") & (filters.group | filters.private))
+    async def help_cmd(_: Client, message: Message):
+        await send_message_safe(message, HELP_TEXT)

--- a/handlers/panels.py
+++ b/handlers/panels.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import logging
 from helpers.compat import Client, CallbackQuery, Message, filters
-from pyrogram.enums import ParseMode
 from config import Config
 from helpers import safe_edit, send_message_safe
 from helpers.panels import (
@@ -36,11 +35,10 @@ async def send_welcome(message: Message, bot_name: str) -> None:
             Config.PANEL_IMAGE,
             caption=text,
             reply_markup=main_panel(),
-            parse_mode=ParseMode.HTML,
         )
     else:
         await send_message_safe(
-            message, text, reply_markup=main_panel(), parse_mode=ParseMode.HTML
+            message, text, reply_markup=main_panel()
         )
 
 
@@ -68,7 +66,9 @@ def register(app: Client):
         data = query.data
         if data == "panel:mod":
             await safe_edit(
-                query.message, "**Moderation**", reply_markup=moderation_panel()
+                query.message,
+                "**Abuse Filter**\nDetects and deletes abusive messages. Warns the user automatically.",
+                reply_markup=moderation_panel(query.message.chat.id),
             )
         elif data == "panel:stats":
             await client.send_message(query.message.chat.id, "/status")
@@ -83,7 +83,6 @@ def register(app: Client):
                 query.message,
                 f"<b>Developer:</b> <a href='{Config.DEV_URL}'>{Config.DEV_NAME}</a>",
                 reply_markup=main_panel(),
-                parse_mode=ParseMode.HTML,
             )
         elif data == "panel:settings":
             await safe_edit(

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -1,0 +1,15 @@
+from helpers.compat import Client, Message, CallbackQuery, filters
+from helpers.panels import settings_panel
+from helpers.formatting import safe_edit
+
+
+def register(app: Client):
+    @app.on_message(filters.command("settings") & (filters.group | filters.private))
+    async def open_settings(client: Client, message: Message):
+        resp = await message.reply("⚙️ Settings", quote=True)
+        await safe_edit(resp, "**Settings**", reply_markup=settings_panel())
+
+    @app.on_callback_query(filters.regex("^settings:"))
+    async def settings_cb(_: Client, query: CallbackQuery):
+        await safe_edit(query.message, "**Settings**", reply_markup=settings_panel())
+        await query.answer()

--- a/handlers/status.py
+++ b/handlers/status.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+import psutil
+from datetime import datetime
+from helpers.compat import Client, Message, filters
+from helpers.formatting import send_message_safe
+from config import Config
+
+START_TIME = datetime.utcnow()
+
+
+def uptime() -> str:
+    delta = datetime.utcnow() - START_TIME
+    seconds = int(delta.total_seconds())
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours}h {minutes}m {secs}s"
+
+
+def register(app: Client):
+    @app.on_message(filters.command("status") & (filters.group | filters.private))
+    async def status_cmd(client: Client, message: Message):
+        process = psutil.Process(os.getpid())
+        mem = process.memory_info().rss // (1024 * 1024)
+        text = (
+            f"\uD83D\uDD0C <b>Status</b>\n"
+            f"Uptime: {uptime()}\n"
+            f"Memory: {mem} MB"
+        )
+        await send_message_safe(message, text, reply_markup=None)

--- a/helpers/panels.py
+++ b/helpers/panels.py
@@ -9,32 +9,39 @@ except Exception:  # pragma: no cover - define minimal stubs
     class InlineKeyboardMarkup(list):
         pass
 
+from helpers.state import get_state
+
 PREFIX = "panel:"
+
+
+def abuse_status(chat_id: int) -> str:
+    s = get_state(chat_id)
+    on = s.text_filter or s.media_filter
+    return "ON" if on else "OFF"
 
 
 def main_panel() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [
-                InlineKeyboardButton("🛡 Moderation", callback_data=f"{PREFIX}mod"),
-                InlineKeyboardButton("📊 Stats", callback_data=f"{PREFIX}stats"),
-            ],
+            [InlineKeyboardButton("🛡 Abuse Filter", callback_data=f"{PREFIX}mod")],
             [InlineKeyboardButton("📢 Broadcast", callback_data=f"{PREFIX}broadcast")],
-            [
-                InlineKeyboardButton("✅ Developer", callback_data=f"{PREFIX}dev"),
-                InlineKeyboardButton("⚙️ Settings", callback_data=f"{PREFIX}settings"),
-            ],
-            [InlineKeyboardButton("📄 Help", callback_data=f"{PREFIX}help")],
+            [InlineKeyboardButton("📶 Status", callback_data=f"{PREFIX}stats")],
+            [InlineKeyboardButton("⚙️ Settings", callback_data=f"{PREFIX}settings")],
+            [InlineKeyboardButton("❓ Help", callback_data=f"{PREFIX}help")],
+            [InlineKeyboardButton("👤 Developer", callback_data=f"{PREFIX}dev")],
             [InlineKeyboardButton("🚪 Exit", callback_data=f"{PREFIX}exit")],
         ]
     )
 
 
-def moderation_panel() -> InlineKeyboardMarkup:
+def moderation_panel(chat_id: int) -> InlineKeyboardMarkup:
+    state = get_state(chat_id)
+    txt = "ON" if state.text_filter else "OFF"
+    med = "ON" if state.media_filter else "OFF"
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("📝 Text Filter", callback_data=f"{PREFIX}text")],
-            [InlineKeyboardButton("🖼 Media Filter", callback_data=f"{PREFIX}media")],
+            [InlineKeyboardButton(f"Text Filter: {txt}", callback_data=f"{PREFIX}text")],
+            [InlineKeyboardButton(f"Media Filter: {med}", callback_data=f"{PREFIX}media")],
             [InlineKeyboardButton("🔙 Back", callback_data=f"{PREFIX}main")],
         ]
     )

--- a/predeploy.py
+++ b/predeploy.py
@@ -25,12 +25,15 @@ REQUIRED_KEYS = [
     "API_HASH",
     "OWNER_ID",
     "LOG_CHANNEL_ID",
+    "MODLOG_CHANNEL_ID",
+    "DEV_URL",
 ]
 
 env = dotenv_values(".env") | os.environ
-for key in REQUIRED_KEYS:
-    if not env.get(key):
-        raise SystemExit(f"Missing required env var: {key}")
+missing = [k for k in REQUIRED_KEYS if not env.get(k)]
+if missing:
+    print(f"[CONFIG ERROR] Missing required env vars: {', '.join(missing)}")
+    raise SystemExit(1)
 if not str(env.get("API_ID", "")).isdigit():
     raise SystemExit("API_ID must be an integer")
 if env.get("API_HASH") and len(env["API_HASH"]) < 30:
@@ -48,6 +51,9 @@ modules = [
     "handlers.panels",
     "handlers.activity_log",
     "handlers.moderation",
+    "handlers.status",
+    "handlers.help",
+    "handlers.settings",
 ]
 for name in modules:
     importlib.import_module(name)

--- a/texts.py
+++ b/texts.py
@@ -1,0 +1,3 @@
+ABUSE_WARNING = "\u26A0\uFE0F Your message was deleted due to abusive content. Please follow the group rules."
+DEVELOPER_LABEL = "\ud83d\udc64 Developer"
+HELP_TEXT = """Available commands:\n/approve @username - approve user\n/unapprove @username - revoke approval\n/rmwarn <user_id> - remove a warning\n/status - show bot status\n/broadcast <text> - send announcement\n/menu - open control panel"""


### PR DESCRIPTION
## Summary
- tweak formatting helpers for safe parse mode fallback
- redesign inline panels and add new status/help/settings handlers
- simplify abuse filtering and add visible warnings
- update configuration handling and example env file
- extend predeploy checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687874c4b8888329bff190009c84ecc7