### PR TITLE
Fix Pydantic v2 imports

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from pydantic import BaseSettings, Field, ValidationError, validator
+"""Configuration models and helpers."""
+
+from pydantic import Field, ValidationError, field_validator
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -26,7 +29,7 @@ class Settings(BaseSettings):
         env_file = ".env"
         case_sensitive = False
 
-    @validator("SUDO_USERS", pre=True)
+    @field_validator("SUDO_USERS", mode="before")
     def _split_sudo(cls, v: str | set[int] | None) -> set[int]:
         if not v:
             return set()


### PR DESCRIPTION
## Summary
- update `config` to import `BaseSettings` from `pydantic_settings`
- use `field_validator` decorator for Pydantic v2

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68787816e028832995ef55addf161a3a